### PR TITLE
refactor: share how a repository is opened, and lock the journal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,13 @@
 
 ## **Did you find a bug?**
 
-- **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/TheDonDope/wits-tui/issues).
+- **Ensure it is not already known** by reading the [ROADMAP.md](./ROADMAP.md). We
+  do not use GitHub Issues: features, bugs and refactorings are tracked there, so
+  that the plan and the code stay in one place.
 
-- If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/TheDonDope/wits-tui/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+- If it is not there, open a pull request adding it to the roadmap, or one fixing
+  it. Include what you expected to happen, what happened instead, and enough to
+  reproduce it.
 
 ## **Did you write a patch that fixes a bug?**
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,26 @@ to the whole history. Entries can be recorded there too.
 | `wits sesh <product> <amount>` | Record a session, drawing on the tin |
 | `wits status` | What is left, and how long it will last |
 | `wits log` | The journal, newest first |
+| `wits revert <entry>` | Undo an entry by recording a correction |
 | `wits device add <name>` | Register a vaporizer |
 | `wits temps <celsius>` | What a temperature is hot enough to release |
 | `wits import <file.xlsx>` | Import a tracking spreadsheet (dry run unless `--commit`) |
 | `wits export` | Markdown, for reading or publishing |
 | `wits bundle` | The whole repository as one compact file |
 | `wits restore <file>` | Rebuild a repository from a bundle |
+
+## Correcting a mistake
+
+Nothing is edited in place. An entry is undone by recording a correction that
+moves the same grams back the way they came, so both stay in the log:
+
+```sh
+wits log --oneline -n 1        # find the entry
+wits revert 8297238 --reason "misread the scale"
+```
+
+In the interface, `e` amends an amount and `d` undoes an entry. The log shows
+what currently stands; `v` reveals the corrections behind it.
 
 ## The repository
 
@@ -116,7 +130,7 @@ products:
 | --- | ---: | --- |
 | journal | 500,729 | |
 | **bundle** | **27,510** | **18×** |
-| bundle, gzipped | 6,297 | 79× |
+| bundle, gzipped | 6,299 | 79× |
 
 ## Temperatures
 
@@ -127,8 +141,9 @@ producing benzene.
 ```sh
 $ wits temps 210
 COMPOUND         BOILS AT  EFFECTS
-Δ-9-THC          157°C     psychoactive, anti-inflammatory, anti-emetic, …
-CBD              165°C     non-psychoactive, anti-inflammatory, anti-anxiety
+THCA             120°C     anti-inflammatory, anti-epileptic, anti-proliferic
+CBDA             130°C     anti-inflammatory, anti-proliferic
+β-Caryophyllene  130°C     anti-malarial, cytoprotective, anti-inflammatory
 …
 ⚠️  210°C is at or above the 205°C boiling point of Benzene.
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -321,6 +321,22 @@ model above rather than fixed in place:
 
 ---
 
+### 🔹 Toward a server and a web interface
+
+- **Status**: Planned
+- **Description**: A `wits-server` exposing a REST API, and a `wits-ui` in Angular.
+  The domain packages are already shared by the commands and the interface, and
+  `pkg/workspace` is what a request handler would open a repository with, so the
+  seam exists. Two things do not yet:
+  - **Concurrency.** Appending is a read-then-write: the tip is read to chain
+    onto. That is now guarded by an advisory file lock as well as a mutex, so two
+    processes cannot fork the chain, but a long-lived server should also cache the
+    fold rather than replay the journal per request.
+  - **Layout.** One Go module with several commands is the plan, rather than a
+    module per component: the domain is shared, and a module boundary between a
+    server and the ledger it serves would mean versioning the ledger against
+    itself. See the notes in the pull request that added this line.
+
 ## 📜 Notes
 
 - Changes will be updated as development progresses.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,18 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
-| < 0.1   | :x:                |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
 
 ## Reporting a Vulnerability
 
-Please use the standard issue mechanism to report a vulnerability, thank you!
+Please report privately through [GitHub's security advisories][advisories] rather
+than in the open, since a repository holds a medical record.
+
+[advisories]: https://github.com/TheDonDope/wits-tui/security/advisories/new
+
+## What a repository contains
+
+A `.wits` directory is health data: what was dispensed, when, and how much was
+used. It is created `0700` with its files `0600`, is never transmitted anywhere,
+and the application makes no network calls at all.

--- a/cmd/wits/commands/bundle.go
+++ b/cmd/wits/commands/bundle.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/TheDonDope/wits-tui/pkg/bundle"
-	"github.com/TheDonDope/wits-tui/pkg/catalog"
 	"github.com/spf13/cobra"
 )
 
@@ -37,11 +36,6 @@ var Bundle = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		devices, err := catalog.LoadDevices(s.repo.DevicesPath())
-		if err != nil {
-			return err
-		}
-
 		var out io.Writer = cmd.OutOrStdout()
 		if bundleOut != "" {
 			f, err := os.OpenFile(bundleOut, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
@@ -58,14 +52,14 @@ var Bundle = &cobra.Command{
 		}
 
 		if err := bundle.Write(out, bundle.Contents{
-			Products: s.catalog,
-			Devices:  devices,
-			Events:   s.state.Events,
+			Products: s.Products,
+			Devices:  s.Devices,
+			Events:   s.State.Events,
 		}); err != nil {
 			return err
 		}
 		if bundleOut != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Bundled %d events into %s\n", len(s.state.Events), bundleOut)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Bundled %d events into %s\n", len(s.State.Events), bundleOut)
 		}
 		return nil
 	},
@@ -88,7 +82,7 @@ var Restore = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if n := len(s.state.Events); n > 0 {
+		if n := len(s.State.Events); n > 0 {
 			return fmt.Errorf("journal already holds %d events; restore into an empty repository", n)
 		}
 
@@ -114,21 +108,21 @@ var Restore = &cobra.Command{
 		}
 
 		if contents.Products != nil && len(contents.Products.Products) > 0 {
-			if err := contents.Products.Save(s.repo.ProductsPath()); err != nil {
+			if err := contents.Products.Save(s.Repo.ProductsPath()); err != nil {
 				return err
 			}
 		}
 		if contents.Devices != nil && len(contents.Devices.Devices) > 0 {
-			if err := contents.Devices.Save(s.repo.DevicesPath()); err != nil {
+			if err := contents.Devices.Save(s.Repo.DevicesPath()); err != nil {
 				return err
 			}
 		}
 		for i, e := range contents.Events {
-			if _, err := s.journal.Append(e); err != nil {
+			if _, err := s.Journal().Append(e); err != nil {
 				return fmt.Errorf("restoring event %d: %w", i+1, err)
 			}
 		}
-		if err := s.journal.Verify(); err != nil {
+		if err := s.Journal().Verify(); err != nil {
 			return fmt.Errorf("the restored journal does not verify: %w", err)
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Restored %d products, %d devices and %d events.\n",

--- a/cmd/wits/commands/buy.go
+++ b/cmd/wits/commands/buy.go
@@ -33,7 +33,7 @@ var Buy = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		e, product, added, err := s.recorder.Buy(args[0], grams, at)
+		e, product, added, err := s.Recorder.Buy(args[0], grams, at)
 		if err != nil {
 			return err
 		}

--- a/cmd/wits/commands/commands.go
+++ b/cmd/wits/commands/commands.go
@@ -8,58 +8,26 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/TheDonDope/wits-tui/pkg/catalog"
-	"github.com/TheDonDope/wits-tui/pkg/journal"
-	"github.com/TheDonDope/wits-tui/pkg/ledger"
-	"github.com/TheDonDope/wits-tui/pkg/record"
-	"github.com/TheDonDope/wits-tui/pkg/repo"
+	"github.com/TheDonDope/wits-tui/pkg/workspace"
 )
 
-// session bundles the repository, its catalog and the folded journal, which is
-// what nearly every command needs before it can do anything.
+// session is the workspace a command runs against, named for what a command
+// does with it.
 type session struct {
-	repo     *repo.Repo
-	catalog  *catalog.Catalog
-	devices  *catalog.Devices
-	journal  *journal.Journal
-	state    *ledger.State
-	recorder *record.Recorder
+	*workspace.Workspace
 }
 
-// open discovers the repository from the working directory and replays its
-// journal.
+// open reads the repository containing the working directory.
 func open() (*session, error) {
-	wd, err := os.Getwd()
+	ws, err := workspace.Here()
 	if err != nil {
 		return nil, err
 	}
-	r, err := repo.Discover(wd)
-	if err != nil {
-		return nil, err
-	}
-	c, err := catalog.Load(r.ProductsPath())
-	if err != nil {
-		return nil, err
-	}
-	j := r.Journal()
-	events, err := j.Events()
-	if err != nil {
-		return nil, err
-	}
-	devices, err := catalog.LoadDevices(r.DevicesPath())
-	if err != nil {
-		return nil, err
-	}
-	state := ledger.Fold(events)
-	return &session{
-		repo: r, catalog: c, journal: j, state: state, devices: devices,
-		recorder: record.New(r, c, devices, state),
-	}, nil
+	return &session{Workspace: ws}, nil
 }
 
 // parseGrams reads an amount written as "0.75", "0.75g" or "0,75 g".

--- a/cmd/wits/commands/device.go
+++ b/cmd/wits/commands/device.go
@@ -33,10 +33,7 @@ var deviceAdd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		devices, err := catalog.LoadDevices(s.repo.DevicesPath())
-		if err != nil {
-			return err
-		}
+		devices := s.Devices
 		device := &catalog.Device{
 			Name:        args[0],
 			Kind:        deviceKind,
@@ -47,7 +44,7 @@ var deviceAdd = &cobra.Command{
 		if err := devices.Add(device); err != nil {
 			return err
 		}
-		if err := devices.Save(s.repo.DevicesPath()); err != nil {
+		if err := devices.Save(s.Repo.DevicesPath()); err != nil {
 			return err
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Added device %s (%s)\n", device.Slug, device.Name)
@@ -64,10 +61,7 @@ var deviceList = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		devices, err := catalog.LoadDevices(s.repo.DevicesPath())
-		if err != nil {
-			return err
-		}
+		devices := s.Devices
 		out := cmd.OutOrStdout()
 		if len(devices.Devices) == 0 {
 			fmt.Fprintln(out, "No devices yet. Add one with `wits device add`.")

--- a/cmd/wits/commands/export.go
+++ b/cmd/wits/commands/export.go
@@ -46,15 +46,15 @@ var Export = &cobra.Command{
 			out = f
 		}
 
-		cycles := s.state.Cycles
+		cycles := s.State.Cycles
 		if !exportAll {
-			if current := s.state.CurrentCycle(); current != nil {
+			if current := s.State.CurrentCycle(); current != nil {
 				cycles = []ledger.Cycle{*current}
 			} else if n := len(cycles); n > 0 {
 				cycles = cycles[n-1:]
 			}
 		}
-		writeMarkdown(out, cycles, s.catalog)
+		writeMarkdown(out, cycles, s.Products)
 
 		if exportOut != "" {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Wrote %d cycle(s) to %s\n", len(cycles), exportOut)

--- a/cmd/wits/commands/grind.go
+++ b/cmd/wits/commands/grind.go
@@ -33,12 +33,12 @@ var Grind = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		e, err := s.recorder.Grind(args[0], grams, at)
+		e, err := s.Recorder.Grind(args[0], grams, at)
 		if err != nil {
 			return err
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "[%s] grind %.2fg %s, %.2fg left in storage\n",
-			shortHash(e.Hash), e.Grams, e.Product, s.recorder.Available(e.Product, journal.Storage))
+			shortHash(e.Hash), e.Grams, e.Product, s.Recorder.Available(e.Product, journal.Storage))
 		return nil
 	},
 }

--- a/cmd/wits/commands/import.go
+++ b/cmd/wits/commands/import.go
@@ -43,7 +43,7 @@ var Import = &cobra.Command{
 			fmt.Fprintf(out, "\nDry run. Nothing was written. Re-run with --commit to import.\n")
 			return nil
 		}
-		if err := importer.Commit(s.repo, result); err != nil {
+		if err := importer.Commit(s.Repo, result); err != nil {
 			return err
 		}
 		fmt.Fprintf(out, "\nImported %d products and %d entries.\n",

--- a/cmd/wits/commands/log.go
+++ b/cmd/wits/commands/log.go
@@ -30,16 +30,16 @@ var Log = &cobra.Command{
 			return err
 		}
 
-		events := s.state.Events
+		events := s.State.Events
 		if logCurrent {
-			if cycle := s.state.CurrentCycle(); cycle != nil {
+			if cycle := s.State.CurrentCycle(); cycle != nil {
 				events = cycle.Events
 			} else {
 				events = nil
 			}
 		}
 		if logProduct != "" {
-			product, err := s.catalog.Find(logProduct)
+			product, err := s.Products.Find(logProduct)
 			if err != nil {
 				return err
 			}

--- a/cmd/wits/commands/revert.go
+++ b/cmd/wits/commands/revert.go
@@ -26,11 +26,11 @@ var Revert = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		original, err := s.recorder.Find(args[0])
+		original, err := s.Recorder.Find(args[0])
 		if err != nil {
 			return err
 		}
-		e, err := s.recorder.Revert(args[0], revertReason)
+		e, err := s.Recorder.Revert(args[0], revertReason)
 		if err != nil {
 			return err
 		}

--- a/cmd/wits/commands/sesh.go
+++ b/cmd/wits/commands/sesh.go
@@ -44,13 +44,13 @@ var Sesh = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		e, err := s.recorder.Session(args[0], grams, at, seshDevice, seshTemp, seshNote)
+		e, err := s.Recorder.Session(args[0], grams, at, seshDevice, seshTemp, seshNote)
 		if err != nil {
 			return err
 		}
 		out := cmd.OutOrStdout()
 		fmt.Fprintf(out, "[%s] sesh %.2fg %s, %.2fg left in the tin\n",
-			shortHash(e.Hash), e.Grams, e.Product, s.recorder.Available(e.Product, journal.Stash))
+			shortHash(e.Hash), e.Grams, e.Product, s.Recorder.Available(e.Product, journal.Stash))
 		if e.Temperature > 0 {
 			writeReleased(out, e.Temperature)
 		}

--- a/cmd/wits/commands/status.go
+++ b/cmd/wits/commands/status.go
@@ -23,7 +23,7 @@ var Status = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		writeStatus(cmd.OutOrStdout(), s.state)
+		writeStatus(cmd.OutOrStdout(), s.State)
 		return nil
 	},
 }

--- a/pkg/journal/journal.go
+++ b/pkg/journal/journal.go
@@ -21,9 +21,36 @@ var ErrBrokenChain = errors.New("journal hash chain is broken")
 // The file is only ever opened for appending. Wits never rewrites it, so a
 // failed or partial write can add a bad line but can never destroy an existing
 // one.
+//
+// Appending is guarded twice over. The mutex serialises writers inside this
+// process; an advisory lock on a file beside the journal serialises them across
+// processes. Both are needed, because appending is a read-then-write: the tip is
+// read to chain onto, and two writers that read the same tip would append two
+// entries claiming the same predecessor and fork the chain. That matters as soon
+// as anything other than a single command talks to a repository.
 type Journal struct {
 	mu   sync.Mutex
 	path string
+}
+
+// lockPath is the file the cross-process lock is taken on. It is separate from
+// the journal so that taking it never opens the journal for writing.
+func (j *Journal) lockPath() string { return j.path + ".lock" }
+
+// lock takes the cross-process append lock, returning the release function.
+func (j *Journal) lock() (func(), error) {
+	f, err := os.OpenFile(j.lockPath(), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockFile(f); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return func() {
+		unlockFile(f)
+		f.Close()
+	}, nil
 }
 
 // Open returns the journal stored at path. The file is created on the first
@@ -41,6 +68,12 @@ func (j *Journal) Path() string { return j.path }
 func (j *Journal) Append(e Event) (Event, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+
+	release, err := j.lock()
+	if err != nil {
+		return Event{}, err
+	}
+	defer release()
 
 	e = withDefaults(e)
 	if err := e.Validate(); err != nil {

--- a/pkg/journal/journal_test.go
+++ b/pkg/journal/journal_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -241,4 +242,47 @@ func TestFlow(t *testing.T) {
 		_, _, ok := Flow("smoke")
 		assert.False(t, ok, "Should not know the type")
 	})
+}
+
+func TestAppendIsSafeAcrossProcesses(t *testing.T) {
+	// Two Journal values over one file stand in for two processes: they share no
+	// mutex, so only the file lock keeps them from reading the same tip and
+	// appending two entries that claim the same predecessor.
+	path := filepath.Join(t.TempDir(), "journal.ndjson")
+
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	start := make(chan struct{})
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			j := Open(path) // its own Journal, its own mutex
+			<-start
+			_, err := j.Append(Event{Type: Grind, Product: "wedding-cake", Grams: 0.5})
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	j := Open(path)
+	events, err := j.Events()
+	require.NoError(t, err)
+	assert.Len(t, events, writers, "Every append should have landed")
+	assert.NoError(t, j.Verify(),
+		"The chain must still verify: without the file lock, two writers read the same tip and fork it")
+
+	seqs := map[int]bool{}
+	for _, e := range events {
+		assert.False(t, seqs[e.Seq], "Sequence %d was used twice", e.Seq)
+		seqs[e.Seq] = true
+	}
 }

--- a/pkg/journal/journal_test.go
+++ b/pkg/journal/journal_test.go
@@ -286,3 +286,29 @@ func TestAppendIsSafeAcrossProcesses(t *testing.T) {
 		seqs[e.Seq] = true
 	}
 }
+
+func TestAppendToAnUnwritableRepository(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, permissions are not enforced")
+	}
+	dir := t.TempDir()
+	j := Open(filepath.Join(dir, "journal.ndjson"))
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() { os.Chmod(dir, 0700) })
+
+	_, err := j.Append(Event{Type: Grind, Product: "wedding-cake", Grams: 1})
+
+	assert.Error(t, err, "Should fail plainly rather than appear to have recorded something")
+}
+
+func TestVerifyReportsAnUnreadableJournal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, permissions are not enforced")
+	}
+	path := filepath.Join(t.TempDir(), "journal.ndjson")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0000))
+
+	err := Open(path).Verify()
+
+	assert.Error(t, err, "Should not report a journal it cannot read as verified")
+}

--- a/pkg/journal/lock_unix.go
+++ b/pkg/journal/lock_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package journal
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockFile takes an exclusive advisory lock on an open file, waiting for any
+// other holder to finish.
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+// unlockFile releases the lock.
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/journal/lock_windows.go
+++ b/pkg/journal/lock_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package journal
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockFile takes an exclusive lock on an open file, waiting for any other
+// holder to finish.
+func lockFile(f *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped)
+}
+
+// unlockFile releases the lock.
+func unlockFile(f *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, overlapped)
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -11,55 +11,25 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/TheDonDope/wits-tui/pkg/catalog"
-	"github.com/TheDonDope/wits-tui/pkg/ledger"
 	"github.com/TheDonDope/wits-tui/pkg/repo"
+	"github.com/TheDonDope/wits-tui/pkg/workspace"
 )
 
-// Data is everything the screens read. It is loaded once and replaced whole
-// when the journal changes, so no screen can drift from another.
+// Data is what the screens read: a workspace snapshot, plus the moment it was
+// taken, so that nothing on screen calls time.Now for itself and disagrees with
+// the rest of the frame.
 type Data struct {
-	Repo     *repo.Repo
-	Products *catalog.Catalog
-	Devices  *catalog.Devices
-	State    *ledger.State
-	Now      time.Time
-}
-
-// Cycle returns the cycle in progress, or nil.
-func (d Data) Cycle() *ledger.Cycle { return d.State.CurrentCycle() }
-
-// ProductName resolves a slug to its display name, falling back to the slug.
-func (d Data) ProductName(slug string) string {
-	if d.Products != nil {
-		if p, err := d.Products.Find(slug); err == nil {
-			return p.Name
-		}
-	}
-	return slug
+	*workspace.Workspace
+	Now time.Time
 }
 
 // Load reads a repository into a Data.
 func Load(r *repo.Repo) (Data, error) {
-	products, err := catalog.Load(r.ProductsPath())
+	ws, err := workspace.Read(r)
 	if err != nil {
 		return Data{}, err
 	}
-	devices, err := catalog.LoadDevices(r.DevicesPath())
-	if err != nil {
-		return Data{}, err
-	}
-	events, err := r.Journal().Events()
-	if err != nil {
-		return Data{}, err
-	}
-	return Data{
-		Repo:     r,
-		Products: products,
-		Devices:  devices,
-		State:    ledger.Fold(events),
-		Now:      time.Now(),
-	}, nil
+	return Data{Workspace: ws, Now: ws.OpenedAt}, nil
 }
 
 // screen is one of the views the tab bar switches between.

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TheDonDope/wits-tui/pkg/catalog"
 	"github.com/TheDonDope/wits-tui/pkg/journal"
 	"github.com/TheDonDope/wits-tui/pkg/ledger"
+	"github.com/TheDonDope/wits-tui/pkg/workspace"
 )
 
 // TestMain handles global test setup
@@ -49,10 +50,12 @@ func sample(t *testing.T) Data {
 	require.NoError(t, products.Add(catalog.Parse("Cannamedical 28/1 Lemon Cookie")))
 
 	return Data{
-		Products: products,
-		Devices:  &catalog.Devices{},
-		State:    ledger.Fold(events),
-		Now:      at.AddDate(0, 0, 4),
+		Workspace: &workspace.Workspace{
+			Products: products,
+			Devices:  &catalog.Devices{},
+			State:    ledger.Fold(events),
+		},
+		Now: at.AddDate(0, 0, 4),
 	}
 }
 
@@ -139,7 +142,9 @@ func TestRendersAtAwkwardSizes(t *testing.T) {
 }
 
 func TestEmptyRepository(t *testing.T) {
-	empty := Data{Products: &catalog.Catalog{}, Devices: &catalog.Devices{}, State: ledger.Fold(nil), Now: time.Now()}
+	empty := Data{Workspace: &workspace.Workspace{
+		Products: &catalog.Catalog{}, Devices: &catalog.Devices{}, State: ledger.Fold(nil),
+	}, Now: time.Now()}
 
 	out := render(t, empty, dashboardScreen, 96, 30)
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -1,0 +1,103 @@
+// Package workspace opens a repository and holds its current state.
+//
+// Opening a repository is the same six steps every time: find it, read the
+// product and device catalogs, read the journal, and fold it. Those steps were
+// written out separately in the commands and in the interface, in different
+// orders, and anything else that wanted to read a repository — a server, say —
+// would have written them a third time. They live here instead.
+//
+// A workspace is a snapshot. It reads the journal once and folds it once, so
+// every screen and every handler working from one sees the same figures.
+// Reload takes a fresh one after something has been written.
+package workspace
+
+import (
+	"os"
+	"time"
+
+	"github.com/TheDonDope/wits-tui/pkg/catalog"
+	"github.com/TheDonDope/wits-tui/pkg/journal"
+	"github.com/TheDonDope/wits-tui/pkg/ledger"
+	"github.com/TheDonDope/wits-tui/pkg/record"
+	"github.com/TheDonDope/wits-tui/pkg/repo"
+)
+
+// Workspace is a repository and everything derived from it.
+type Workspace struct {
+	Repo     *repo.Repo
+	Products *catalog.Catalog
+	Devices  *catalog.Devices
+	State    *ledger.State
+	Recorder *record.Recorder
+
+	// OpenedAt is when the snapshot was taken. Anything reporting "how long has
+	// this cycle been running" should measure against it rather than call
+	// time.Now itself, so a single view cannot disagree with itself.
+	OpenedAt time.Time
+}
+
+// Open finds the repository containing dir and reads it.
+func Open(dir string) (*Workspace, error) {
+	r, err := repo.Discover(dir)
+	if err != nil {
+		return nil, err
+	}
+	return Read(r)
+}
+
+// Here opens the repository containing the working directory.
+func Here() (*Workspace, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return Open(wd)
+}
+
+// Read loads an already-discovered repository.
+func Read(r *repo.Repo) (*Workspace, error) {
+	products, err := catalog.Load(r.ProductsPath())
+	if err != nil {
+		return nil, err
+	}
+	devices, err := catalog.LoadDevices(r.DevicesPath())
+	if err != nil {
+		return nil, err
+	}
+	events, err := r.Journal().Events()
+	if err != nil {
+		return nil, err
+	}
+	state := ledger.Fold(events)
+	return &Workspace{
+		Repo:     r,
+		Products: products,
+		Devices:  devices,
+		State:    state,
+		Recorder: record.New(r, products, devices, state),
+		OpenedAt: time.Now(),
+	}, nil
+}
+
+// Reload returns a fresh snapshot of the same repository.
+func (w *Workspace) Reload() (*Workspace, error) { return Read(w.Repo) }
+
+// Journal returns the repository's journal.
+func (w *Workspace) Journal() *journal.Journal { return w.Repo.Journal() }
+
+// Events returns the entries the snapshot was folded from.
+func (w *Workspace) Events() []journal.Event { return w.State.Events }
+
+// Cycle returns the prescription cycle in progress, or nil.
+func (w *Workspace) Cycle() *ledger.Cycle { return w.State.CurrentCycle() }
+
+// ProductName resolves a slug to its display name, falling back to the slug so
+// that an entry for a product missing from the catalog still reads sensibly.
+func (w *Workspace) ProductName(slug string) string {
+	if w.Products != nil {
+		if p, err := w.Products.Find(slug); err == nil {
+			return p.Name
+		}
+	}
+	return slug
+}

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -117,3 +117,55 @@ func TestReadEmptyRepository(t *testing.T) {
 	assert.Nil(t, ws.Cycle(), "Should report no cycle")
 	assert.NotNil(t, ws.Recorder, "and should still be ready to record the first entry")
 }
+
+func TestHere(t *testing.T) {
+	t.Run("OpensTheRepositoryAroundTheWorkingDirectory", func(t *testing.T) {
+		r := filled(t)
+		nested := filepath.Join(r.WorkTree(), "notes")
+		require.NoError(t, os.MkdirAll(nested, 0700))
+		t.Chdir(nested)
+
+		ws, err := Here()
+		require.NoError(t, err)
+
+		assert.Equal(t, r.Root(), ws.Repo.Root(), "Should find the repository from where it is run")
+		assert.Len(t, ws.Events(), 2, "and should have read it")
+	})
+
+	t.Run("WithoutARepository", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		_, err := Here()
+
+		assert.ErrorIs(t, err, repo.ErrNotARepo, "Should say there is no repository here")
+	})
+}
+
+func TestJournalIsTheRepositoryJournal(t *testing.T) {
+	r := filled(t)
+	ws, err := Read(r)
+	require.NoError(t, err)
+
+	assert.Equal(t, r.Journal().Path(), ws.Journal().Path(), "Should hand out the repository's own journal")
+	assert.NoError(t, ws.Journal().Verify(), "which should verify")
+}
+
+func TestReadRefusesABrokenCatalog(t *testing.T) {
+	r, err := repo.Init(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(r.ProductsPath(), []byte("products: [oh dear\n"), 0600))
+
+	_, err = Read(r)
+
+	assert.Error(t, err, "Should refuse to open rather than quietly treat a broken catalog as empty")
+}
+
+func TestReadRefusesABrokenJournal(t *testing.T) {
+	r, err := repo.Init(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(r.Journal().Path(), []byte("not json\n"), 0600))
+
+	_, err = Read(r)
+
+	assert.Error(t, err, "Should refuse to open rather than fold a journal it could not read")
+}

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -1,0 +1,119 @@
+package workspace
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TheDonDope/wits-tui/pkg/journal"
+	"github.com/TheDonDope/wits-tui/pkg/repo"
+)
+
+// TestMain handles global test setup
+func TestMain(m *testing.M) {
+	// Disable log output during tests
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
+
+// filled returns a repository holding one fill and one grind.
+func filled(t *testing.T) *repo.Repo {
+	t.Helper()
+	r, err := repo.Init(t.TempDir())
+	require.NoError(t, err)
+
+	ws, err := Read(r)
+	require.NoError(t, err)
+	_, _, _, err = ws.Recorder.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	require.NoError(t, err)
+	_, err = ws.Recorder.Grind("wedding", 0.75, time.Now())
+	require.NoError(t, err)
+	return r
+}
+
+func TestRead(t *testing.T) {
+	ws, err := Read(filled(t))
+	require.NoError(t, err)
+
+	assert.Len(t, ws.Events(), 2, "Should have read the journal")
+	assert.Len(t, ws.Products.Products, 1, "Should have read the catalog")
+	assert.NotNil(t, ws.Devices, "Should have read the devices, even when there are none")
+	assert.Equal(t, 19.25, ws.State.Balances["enua-wedding-cake"].Storage, "Should have folded the journal")
+	assert.NotNil(t, ws.Recorder, "Should be ready to record")
+	assert.False(t, ws.OpenedAt.IsZero(), "Should stamp when the snapshot was taken")
+}
+
+func TestOpenFindsTheRepositoryFromBelow(t *testing.T) {
+	r := filled(t)
+	nested := filepath.Join(r.WorkTree(), "a", "b")
+	require.NoError(t, os.MkdirAll(nested, 0700))
+
+	ws, err := Open(nested)
+	require.NoError(t, err)
+
+	assert.Equal(t, r.Root(), ws.Repo.Root(), "Should walk up to the repository")
+}
+
+func TestOpenWithoutARepository(t *testing.T) {
+	_, err := Open(t.TempDir())
+
+	assert.ErrorIs(t, err, repo.ErrNotARepo, "Should report a missing repository rather than inventing one")
+}
+
+func TestSnapshotDoesNotMoveUnderneath(t *testing.T) {
+	r := filled(t)
+	ws, err := Read(r)
+	require.NoError(t, err)
+	before := len(ws.Events())
+
+	// Something else writes to the same repository.
+	_, err = r.Journal().Append(journal.Event{
+		Type: journal.Grind, Product: "enua-wedding-cake", Grams: 0.5,
+		From: journal.Storage, To: journal.Stash, OccurredAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, ws.Events(), before,
+		"A snapshot should not change under a screen that is drawing from it")
+
+	fresh, err := ws.Reload()
+	require.NoError(t, err)
+	assert.Len(t, fresh.Events(), before+1, "and Reload should pick the new entry up")
+}
+
+func TestProductName(t *testing.T) {
+	ws, err := Read(filled(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Enua 22/1 Wedding Cake", ws.ProductName("enua-wedding-cake"),
+		"Should resolve a slug to its display name")
+	assert.Equal(t, "not-in-the-catalog", ws.ProductName("not-in-the-catalog"),
+		"and should fall back to the slug, so an orphaned entry still reads sensibly")
+}
+
+func TestCycle(t *testing.T) {
+	ws, err := Read(filled(t))
+	require.NoError(t, err)
+
+	cycle := ws.Cycle()
+	require.NotNil(t, cycle, "Should report the cycle in progress")
+	assert.Equal(t, 20.0, cycle.Purchased, "Should be the fill that opened it")
+}
+
+func TestReadEmptyRepository(t *testing.T) {
+	r, err := repo.Init(t.TempDir())
+	require.NoError(t, err)
+
+	ws, err := Read(r)
+	require.NoError(t, err)
+
+	assert.Empty(t, ws.Events(), "Should read as empty rather than failing")
+	assert.Nil(t, ws.Cycle(), "Should report no cycle")
+	assert.NotNil(t, ws.Recorder, "and should still be ready to record the first entry")
+}

--- a/wits-demo.tape
+++ b/wits-demo.tape
@@ -58,11 +58,41 @@
 Output vhs-output/wits-demo.gif
 
 Set Shell "bash"
-Set FontSize 24 
+Set FontSize 24
 Set FontFamily "JetBrainsMono Nerd Font"
-Set Width 1400 
+Set Width 1400
 Set Height 900
 
-Type "./bin/wits" Sleep 500ms  Enter
+# A throwaway repository first. `wits` reads a .wits directory and a source
+# checkout has none, so without this the tape would only record the words
+# "not a wits repository".
+Hide
+Type "export PATH=$PWD/bin:$PATH" Enter
+Type "rm -rf /tmp/wits-demo && mkdir -p /tmp/wits-demo && cd /tmp/wits-demo" Enter
+Type "wits init ." Enter
+Type "wits device add 'Volcano Hybrid' --kind desktop --min 40 --max 230 --default 185" Enter
+Type "wits buy 'Enua 22/1 Wedding Cake' 20g --date 2026-07-09" Enter
+Type "wits buy 'Cannamedical 28/1 Lemon Cookie' 20g --date 2026-07-09" Enter
+Type "wits buy 'Cantourage 25/1 MAC1+' 20g --date 2026-07-09" Enter
+Type "wits grind wedding 0.75 --date 2026-07-10" Enter
+Type "wits sesh wedding 0.30 --device volcano --date 2026-07-10" Enter
+Type "wits grind lemon 1.25 --date 2026-07-11" Enter
+Type "wits grind mac1 0.90 --date 2026-07-12" Enter
+Type "wits grind wedding 1.10 --date 2026-07-13" Enter
+Type "wits grind lemon 0.85 --date 2026-07-14" Enter
+Type "clear" Enter
+Show
 
-Sleep 5s
+# What is left, and how long it will last.
+Type "wits status" Sleep 500ms Enter
+Sleep 4s
+Type "clear" Sleep 300ms Enter
+
+# The interface: dashboard, journal, analysis, devices.
+Type "wits" Sleep 500ms Enter
+Sleep 3s
+Tab Sleep 3s
+Tab Sleep 3s
+Tab Sleep 3s
+Type "q"
+Sleep 1s


### PR DESCRIPTION
## Description

A round of cleanup before the server work starts, plus one latent bug that the server would have turned into a real one.

### Appending to the journal was not safe across processes

`Append` is a read-then-write: it reads the tip to chain onto, computes `Prev`, then writes. That was guarded by a `sync.Mutex`, which only ever holds **within one process**.

Nothing does that today — a command is one process and the interface is another, and they do not run at once. But `wits-server` alongside a `wits grind` is exactly two writers on one repository: both read the same tip, both append an entry claiming the same predecessor, and the chain forks. `Verify` would catch it afterwards, which in a medical record is the wrong time to find out.

An advisory lock on a file beside the journal now guards it as well, on Unix (`flock`) and Windows (`LockFileEx`). The test stands two `Journal` values over one file — sharing no mutex, standing in for two processes. Removing the lock makes it fail with `Sequence 1 was used twice` and a chain that will not verify, so it is testing what it claims to.

Much cheaper to fix now than to detect later.

### Opening a repository lived in two places

It is the same six steps every time — find the repository, read the product and device catalogs, read the journal, fold it. The commands and the interface each spelled it out separately, in different orders, and a server would have written it a third time.

`pkg/workspace` now owns it, and both callers are thin wrappers over it: 77 lines out of `commands.open()` and `tui.Load()` between them. `status` output is byte-identical before and after, checked against the imported four-year repository.

A workspace is a **snapshot**: it reads and folds once, so a screen drawing from it cannot disagree with itself halfway down the frame, and `Reload` takes a fresh one after something is written. It carries the moment it was taken, so nothing calls `time.Now` on its own and reports a different day than the frame around it. That is what a request handler wants too.

Only `workspace` loads catalogs now, apart from the importer, which runs before a workspace can exist.

### Documentation caught up with the program

- **The demo GIF was worse than stale — its tape could no longer be recorded at all.** It ran the binary in a source checkout, which has no `.wits`, so it would only have recorded the words *"not a wits repository"*. The tape now provisions a throwaway repository and tours the four screens. The GIF itself is out of the README until it can be re-recorded (`make install && make render-tapes`), rather than left showing an interface that no longer exists.
- The README was missing `wits revert`, and its `wits temps 210` example listed compounds the command does not actually print first. Both checked against the binary rather than from memory. Added a short section on correcting a mistake, since that is the least obvious part of an append-only log.
- `CONTRIBUTING.md` told people to open GitHub Issues while the README says we deliberately do not use them.
- `SECURITY.md` claimed `0.1.x` was the supported line at v0.6, and said nothing about what a repository holds. It now says: health data, `0700`/`0600`, never transmitted, no network calls at all — and points at private advisories rather than the open issue tracker.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] `go test ./... -race`, `go vet`, `gofmt` and `revive` all clean
- [x] Builds for Linux **and** Windows, since the lock is platform-specific
- [x] The cross-process lock test verified to be non-vacuous by removing the lock and watching it fail
- [x] New tests for `pkg/workspace`: discovery from a subdirectory, a missing repository, an empty repository, name resolution falling back to the slug, and that a snapshot does not change under a screen while something else writes to the same repository
- [x] Behaviour unchanged end to end: imported the real workbook again and diffed `wits status` against the pre-refactor run — identical

**Test Configuration**: Go 1.26.5, Linux

## Notes for the reviewer

Two things about the layout, ahead of the server:

- **The fold is replayed every time a repository is opened.** 1369 entries is milliseconds, so it does not matter yet; a long-lived server should cache it. `wits reindex` is already on the roadmap and is exactly that.
- **One Go module with several commands**, rather than a module per component. The domain packages are shared by the commands and the interface, and a module boundary between a server and the ledger it serves would mean versioning the ledger against itself on every change.

The dependency graph is already clean and acyclic — `journal` at the base, nothing circular — so moving to `cmd/wits` + `cmd/wits-server` + `web/` is a rename rather than a restructure.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
