### PR TITLE
feat: add a products screen and reconciling against the scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ About 24 days left at that rate
 
 `wits` on its own opens the interface: a dashboard of what is left and how long
 it will last, the journal, an analysis view scoping from the current cycle out to
-the whole history, and the devices. Entries can be recorded there too — `n` to
-grind, `s` for a session, `b` for a fill.
+the whole history, the products and the devices. Entries can be recorded there
+too — `n` to grind, `s` for a session, `b` for a fill, `r` to weigh.
 
 ## Commands
 
@@ -102,6 +102,7 @@ grind, `s` for a session, `b` for a fill.
 | `wits status` | What is left, and how long it will last |
 | `wits log` | The journal, newest first |
 | `wits revert <entry>` | Undo an entry by recording a correction |
+| `wits reconcile <product> <weight>` | Make an account agree with the scale |
 | `wits device add <name>` | Register a vaporizer |
 | `wits temps <celsius>` | What a temperature is hot enough to release |
 | `wits import <file.xlsx>` | Import a tracking spreadsheet |
@@ -123,6 +124,25 @@ wits revert 8297238 --reason "misread the scale"
 
 In the interface, `e` amends an amount and `d` undoes an entry. The log shows what
 currently stands; `v` reveals the corrections behind it.
+
+## When the ledger and the scale disagree
+
+Ledgers drift. A little is spilled, a session goes unlogged, a scale is read
+wrong. The past is not edited to hide it, because nobody knows which entry was
+wrong — instead the difference is recorded, and the account agrees with the jar
+again:
+
+```console
+$ wits reconcile wedding-cake 17.6 --dry-run
+storage holds 18.00g by the ledger and 17.60g on the scale: -0.40g
+
+$ wits reconcile wedding-cake 17.6 --reason "spilled on the desk"
+[21ee6ae] adjusted 0.40g out of storage, now 17.60g
+```
+
+`--stash` weighs the tin instead, `--avb` the already vaped bud. In the interface
+this is `r`, on any screen — it offers the jar under the cursor on the products
+screen, or otherwise the fullest one, since that is the one worth checking.
 
 ## The repository
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,8 +86,8 @@ rows, so its average depended on how far ahead it had been filled in.
 
 ### The commands
 
-`init`, `buy`, `grind`, `sesh`, `status`, `log`, `revert`, `device`, `temps`,
-`import`, `export`, `bundle`, `restore`. Only the parts of git's vocabulary with
+`init`, `buy`, `grind`, `sesh`, `status`, `log`, `revert`, `reconcile`, `device`,
+`temps`, `import`, `export`, `bundle`, `restore`. Only the parts of git's vocabulary with
 a real referent were borrowed; branching and merging mean nothing for a
 prescription and are absent.
 
@@ -146,6 +146,18 @@ The log shows what currently stands; `v` reveals the corrections behind it. They
 are hidden rather than removed — that is the difference between a record that can
 be audited and one that cannot.
 
+### Products and reconciliation
+
+A products screen listing what is on the shelf — storage, tin, AVB and grams
+ground, with the potency and how much of the fill is still held. It lists what is
+held by default and everything ever dispensed on `a`, because a catalog
+remembering four years of prescriptions is a history rather than a shelf.
+
+`wits reconcile`, and `r` in the interface, record the difference between what
+the ledger believes an account holds and what it actually weighs. Nothing in the
+past is edited: the difference becomes an adjustment, which is a transfer like
+any other, so the accounts still balance afterwards.
+
 ### Temperatures and devices
 
 Every cannabinoid and terpene with its boiling point, so a setting on a dial reads
@@ -166,15 +178,10 @@ range is checked when it is typed rather than later when a session is refused.
   recorded grinding. Nothing was invented to fill that gap, so the stash balance
   of a product recurring across cycles reads high until it is worked down.
 
-### 🔹 A products screen
+### 🔹 Editing a product, and splitting ones the slug merged
 
 - **Status**: Planned
-- Devices have one; products do not. Wanted: browsing the catalog, correcting a
-  parsed name, and merging two products the slug split or joined.
-
-### 🔹 Splitting products the slug merged
-
-- **Status**: Planned
+- The products screen lists and weighs; it cannot yet correct a parsed name.
 - `Slugify` drops the THC ratio, so the same cultivar from one manufacturer at two
   potencies becomes one product. The importer reports these rather than doing it
   quietly, but there is no way to split them afterwards.

--- a/cmd/wits/commands/commands_test.go
+++ b/cmd/wits/commands/commands_test.go
@@ -257,3 +257,70 @@ func TestHomeCommand(t *testing.T) {
 			"and should have got as far as launching")
 	})
 }
+
+func TestReconcileCommand(t *testing.T) {
+	stocked := func(t *testing.T) string {
+		t.Helper()
+		dir := repository(t)
+		_, err := run(t, dir, Buy, "Enua 22/1 Wedding Cake", "20g")
+		require.NoError(t, err)
+		_, err = run(t, dir, Grind, "wedding", "2")
+		require.NoError(t, err)
+		return dir
+	}
+
+	t.Run("RecordsTheDifference", func(t *testing.T) {
+		dir := stocked(t)
+
+		out, err := run(t, dir, Reconcile, "wedding", "17.6")
+
+		require.NoError(t, err)
+		assert.Contains(t, out, "0.40g", "Should record the difference, not the weight")
+		assert.Contains(t, out, "out of storage", "Should say which way the grams went")
+		assert.Contains(t, out, "now 17.60g", "and what the account holds now")
+	})
+
+	t.Run("DryRunWritesNothing", func(t *testing.T) {
+		dir := stocked(t)
+		defer func() { reconcileDryRun = false }()
+
+		out, err := run(t, dir, Reconcile, "wedding", "17.6", "--dry-run")
+
+		require.NoError(t, err)
+		assert.Contains(t, out, "-0.40g", "Should show the signed difference")
+		assert.Contains(t, out, "Dry run", "Should say it wrote nothing")
+
+		status, err := run(t, dir, Status)
+		require.NoError(t, err)
+		assert.Contains(t, status, "18.00g", "and storage should be untouched")
+	})
+
+	t.Run("TheTin", func(t *testing.T) {
+		dir := stocked(t)
+		defer func() { reconcileStash = false }()
+
+		out, err := run(t, dir, Reconcile, "wedding", "1.75", "--stash")
+
+		require.NoError(t, err)
+		assert.Contains(t, out, "out of stash", "Should weigh the tin when asked to")
+	})
+
+	t.Run("NothingToReconcile", func(t *testing.T) {
+		dir := stocked(t)
+
+		_, err := run(t, dir, Reconcile, "wedding", "18")
+
+		assert.ErrorContains(t, err, "already matches the scale",
+			"Should say so rather than record a zero-gram adjustment")
+	})
+
+	t.Run("RefusesTwoAccountsAtOnce", func(t *testing.T) {
+		dir := stocked(t)
+		defer func() { reconcileStash, reconcileAVB = false, false }()
+
+		_, err := run(t, dir, Reconcile, "wedding", "1", "--stash", "--avb")
+
+		assert.ErrorContains(t, err, "one account at a time",
+			"Should refuse rather than silently pick one")
+	})
+}

--- a/cmd/wits/commands/reconcile.go
+++ b/cmd/wits/commands/reconcile.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/TheDonDope/wits/pkg/journal"
+)
+
+var (
+	reconcileStash  bool
+	reconcileAVB    bool
+	reconcileReason string
+	reconcileDryRun bool
+)
+
+// Reconcile is the `wits reconcile` command.
+var Reconcile = &cobra.Command{
+	Use:   "reconcile <product> <weight>",
+	Short: "Make an account agree with the scale",
+	Long: "Record the difference between what the ledger believes an account holds\n" +
+		"and what it actually weighs.\n\n" +
+		"Ledgers drift: a little is spilled, a session goes unlogged, a scale is\n" +
+		"read wrong. The past is not edited to hide it, because nobody knows which\n" +
+		"entry was wrong. Instead the difference is recorded as an adjustment, and\n" +
+		"the account agrees with the jar again.\n\n" +
+		"Storage is reconciled by default; --stash weighs the tin and --avb the\n" +
+		"already vaped bud.",
+	Example: "  wits reconcile wedding-cake 17.6\n" +
+		"  wits reconcile wedding-cake 1.75 --stash --reason \"spilled on the desk\"\n" +
+		"  wits reconcile wedding-cake 17.6 --dry-run",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, err := open()
+		if err != nil {
+			return err
+		}
+		weighed, err := parseGrams(args[1])
+		if err != nil {
+			return err
+		}
+		account, err := reconcileAccount()
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		if reconcileDryRun {
+			expected, difference, err := s.Recorder.Difference(args[0], account, weighed)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s holds %.2fg by the ledger and %.2fg on the scale: %+.2fg\n",
+				account, expected, weighed, difference)
+			if difference == 0 {
+				fmt.Fprintln(out, "Nothing to reconcile.")
+				return nil
+			}
+			fmt.Fprintln(out, "\nDry run. Nothing was written. Re-run without --dry-run to record it.")
+			return nil
+		}
+
+		e, err := s.Recorder.Reconcile(args[0], account, weighed, reconcileReason)
+		if err != nil {
+			return err
+		}
+		direction := "into"
+		if e.To == journal.External {
+			direction = "out of"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "[%s] adjusted %.2fg %s %s, now %.2fg\n",
+			shortHash(e.Hash), e.Grams, direction, account,
+			s.Recorder.Available(e.Product, account))
+		return nil
+	},
+}
+
+// reconcileAccount reads which account the flags select.
+func reconcileAccount() (journal.Account, error) {
+	switch {
+	case reconcileStash && reconcileAVB:
+		return "", fmt.Errorf("weigh one account at a time: --stash or --avb")
+	case reconcileStash:
+		return journal.Stash, nil
+	case reconcileAVB:
+		return journal.AVB, nil
+	default:
+		return journal.Storage, nil
+	}
+}
+
+func init() {
+	Reconcile.Flags().BoolVar(&reconcileStash, "stash", false, "weigh the tin rather than storage")
+	Reconcile.Flags().BoolVar(&reconcileAVB, "avb", false, "weigh the already vaped bud")
+	Reconcile.Flags().StringVar(&reconcileReason, "reason", "", "why the amounts differ")
+	Reconcile.Flags().BoolVar(&reconcileDryRun, "dry-run", false, "show the difference without recording it")
+}

--- a/cmd/wits/main.go
+++ b/cmd/wits/main.go
@@ -56,6 +56,7 @@ func init() {
 		commands.Temps,
 		commands.Status,
 		commands.Log,
+		commands.Reconcile,
 		commands.Restore,
 		commands.Revert,
 		commands.Export,

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -7,7 +7,9 @@
 package record
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -261,3 +263,78 @@ func short(h string) string {
 	}
 	return h
 }
+
+// ErrNothingToReconcile is returned when the scale agrees with the ledger.
+var ErrNothingToReconcile = errors.New("the ledger already matches the scale")
+
+// reconcilable are the accounts that hold something you can put on a scale.
+// Consumed is not one of them: it is what has gone through a device and is on
+// its way to becoming AVB, and there is no jar of it to weigh.
+var reconcilable = map[journal.Account]string{
+	journal.Storage: "storage",
+	journal.Stash:   "the tin",
+	journal.AVB:     "the AVB jar",
+}
+
+// Reconcile records the difference between what the ledger believes an account
+// holds and what the scale actually reads.
+//
+// Ledgers drift: a little is spilled, a session goes unlogged, a scale is read
+// wrong. The honest repair is not to edit the past — nobody knows which entry
+// was wrong — but to record that the account is now known to hold a different
+// amount, and by how much. The difference becomes an adjustment, which the fold
+// applies like any other transfer.
+func (r *Recorder) Reconcile(ref string, account journal.Account, weighed float64, note string) (journal.Event, error) {
+	where, ok := reconcilable[account]
+	if !ok {
+		return journal.Event{}, fmt.Errorf("%s cannot be weighed", account)
+	}
+	product, err := r.products.Find(ref)
+	if err != nil {
+		return journal.Event{}, err
+	}
+	if weighed < 0 {
+		return journal.Event{}, fmt.Errorf("a weight cannot be negative, got %.2f", weighed)
+	}
+
+	expected := r.Available(product.Slug, account)
+	difference := round(weighed - expected)
+	if difference == 0 {
+		return journal.Event{}, fmt.Errorf("%w: %.2f g in %s", ErrNothingToReconcile, expected, where)
+	}
+
+	// Grams that are there but unaccounted for come in from outside the system;
+	// grams the ledger has but the jar does not have gone out of it. Either way
+	// the entry is a transfer, so the accounts still balance afterwards.
+	from, to := journal.External, account
+	if difference < 0 {
+		from, to = account, journal.External
+	}
+	if note == "" {
+		note = fmt.Sprintf("reconciled %s: %.2f g weighed, %.2f g expected", where, weighed, expected)
+	}
+	return r.append(journal.Event{
+		Type:       journal.Adjust,
+		Product:    product.Slug,
+		Grams:      math.Abs(difference),
+		From:       from,
+		To:         to,
+		OccurredAt: time.Now(),
+		Note:       note,
+	})
+}
+
+// Difference reports what reconciling an account to a weighed amount would
+// change, without recording anything. A screen can show it before it is
+// committed to.
+func (r *Recorder) Difference(ref string, account journal.Account, weighed float64) (expected, difference float64, err error) {
+	product, err := r.products.Find(ref)
+	if err != nil {
+		return 0, 0, err
+	}
+	expected = r.Available(product.Slug, account)
+	return expected, round(weighed - expected), nil
+}
+
+// round trims to centigrams, the precision a jeweller's scale reads.
+func round(g float64) float64 { return math.Round(g*100) / 100 }

--- a/pkg/record/record_test.go
+++ b/pkg/record/record_test.go
@@ -207,3 +207,132 @@ func TestReverted(t *testing.T) {
 	assert.True(t, hidden[fix.Hash], "and so should the correction itself")
 	assert.Len(t, hidden, 2, "but nothing else")
 }
+
+// stocked returns a recorder holding 20 g of one product, 2 g of it ground.
+func stocked(t *testing.T) *Recorder {
+	t.Helper()
+	rec := recorder(t)
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	require.NoError(t, err)
+	_, err = rec.Grind("wedding", 2, time.Now())
+	require.NoError(t, err)
+	return rec
+}
+
+func TestReconcile(t *testing.T) {
+	t.Run("LessOnTheScaleThanInTheLedger", func(t *testing.T) {
+		rec := stocked(t)
+
+		// 17.60 weighed against 18.00 expected: 0.40 g went somewhere unlogged.
+		e, err := rec.Reconcile("wedding", journal.Storage, 17.60, "")
+		require.NoError(t, err)
+
+		assert.Equal(t, journal.Adjust, e.Type, "Should record an adjustment")
+		assert.InDelta(t, 0.40, e.Grams, 0.001, "Should record the difference, not the weight")
+		assert.Equal(t, journal.Storage, e.From, "Should take the grams out of storage")
+		assert.Equal(t, journal.External, e.To, "and out of the system")
+		assert.InDelta(t, 17.60, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+			"Storage should now agree with the scale")
+	})
+
+	t.Run("MoreOnTheScaleThanInTheLedger", func(t *testing.T) {
+		rec := stocked(t)
+
+		e, err := rec.Reconcile("wedding", journal.Storage, 18.50, "")
+		require.NoError(t, err)
+
+		assert.InDelta(t, 0.50, e.Grams, 0.001, "Should record the difference")
+		assert.Equal(t, journal.External, e.From, "Should bring the grams in from outside")
+		assert.Equal(t, journal.Storage, e.To, "and into storage")
+		assert.InDelta(t, 18.50, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+			"Storage should now agree with the scale")
+	})
+
+	t.Run("TheTin", func(t *testing.T) {
+		rec := stocked(t)
+
+		_, err := rec.Reconcile("wedding", journal.Stash, 1.75, "")
+		require.NoError(t, err)
+
+		assert.InDelta(t, 1.75, rec.Available("enua-wedding-cake", journal.Stash), 0.001,
+			"Should reconcile the tin as readily as storage")
+		assert.InDelta(t, 18.0, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+			"and should leave the other accounts alone")
+	})
+
+	t.Run("NothingToDo", func(t *testing.T) {
+		rec := stocked(t)
+		before := len(rec.State().Events)
+
+		_, err := rec.Reconcile("wedding", journal.Storage, 18.00, "")
+
+		assert.ErrorIs(t, err, ErrNothingToReconcile, "Should say so rather than record a zero")
+		assert.Len(t, rec.State().Events, before, "and should record nothing")
+	})
+
+	t.Run("WeighingToNothing", func(t *testing.T) {
+		rec := stocked(t)
+
+		_, err := rec.Reconcile("wedding", journal.Storage, 0, "an empty jar")
+		require.NoError(t, err)
+
+		assert.Zero(t, rec.Available("enua-wedding-cake", journal.Storage),
+			"An empty jar is a legitimate reading, and should empty the account")
+	})
+
+	t.Run("RecordsWhyByDefault", func(t *testing.T) {
+		rec := stocked(t)
+
+		e, err := rec.Reconcile("wedding", journal.Storage, 17.60, "")
+		require.NoError(t, err)
+
+		assert.Contains(t, e.Note, "17.60", "Should note what was weighed")
+		assert.Contains(t, e.Note, "18.00", "and what was expected, since the entry itself only carries the difference")
+	})
+
+	t.Run("KeepsAGivenReason", func(t *testing.T) {
+		rec := stocked(t)
+
+		e, err := rec.Reconcile("wedding", journal.Storage, 17.60, "spilled on the desk")
+		require.NoError(t, err)
+
+		assert.Equal(t, "spilled on the desk", e.Note, "Should keep what was actually said")
+	})
+
+	t.Run("Refusals", func(t *testing.T) {
+		rec := stocked(t)
+
+		_, err := rec.Reconcile("wedding", journal.Storage, -1, "")
+		assert.ErrorContains(t, err, "cannot be negative", "Should refuse a negative weight")
+
+		_, err = rec.Reconcile("wedding", journal.Consumed, 1, "")
+		assert.ErrorContains(t, err, "cannot be weighed",
+			"Should refuse an account with no jar to put on a scale")
+
+		_, err = rec.Reconcile("blueberry", journal.Storage, 1, "")
+		assert.Error(t, err, "Should refuse a product it has never seen")
+	})
+
+	t.Run("MassStillBalancesAfterwards", func(t *testing.T) {
+		rec := stocked(t)
+		_, err := rec.Reconcile("wedding", journal.Storage, 17.60, "")
+		require.NoError(t, err)
+
+		// An adjustment is a transfer, so the fold still accounts for every gram
+		// that came in, including the ones that left again.
+		b := rec.State().Balances["enua-wedding-cake"]
+		assert.InDelta(t, 19.60, b.Storage+b.Stash+b.Consumed+b.AVB, 0.001,
+			"20 g bought, 0.40 g adjusted out")
+	})
+}
+
+func TestDifference(t *testing.T) {
+	rec := stocked(t)
+
+	expected, difference, err := rec.Difference("wedding", journal.Storage, 17.60)
+	require.NoError(t, err)
+
+	assert.InDelta(t, 18.00, expected, 0.001, "Should report what the ledger believes")
+	assert.InDelta(t, -0.40, difference, 0.001, "and the signed difference")
+	assert.Len(t, rec.State().Events, 2, "without recording anything")
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -45,11 +45,12 @@ const (
 	dashboardScreen screen = iota
 	journalScreen
 	analysisScreen
+	productsScreen
 	devicesScreen
 )
 
 // tabs are the screen names, in order.
-var tabs = []string{"Dashboard", "Journal", "Analysis", "Devices"}
+var tabs = []string{"Dashboard", "Journal", "Analysis", "Products", "Devices"}
 
 // keyMap is the global key bindings. Screens add their own on top.
 type keyMap struct {
@@ -59,6 +60,7 @@ type keyMap struct {
 	Top, Bottom    key.Binding
 	Help, Quit     key.Binding
 	New, Sesh, Buy key.Binding
+	Weigh          key.Binding
 }
 
 func defaultKeys() keyMap {
@@ -74,6 +76,7 @@ func defaultKeys() keyMap {
 		New:    key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "grind")),
 		Sesh:   key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sesh")),
 		Buy:    key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "buy")),
+		Weigh:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "weigh")),
 		Help:   key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 		Quit:   key.NewBinding(key.WithKeys("q", "ctrl+c", "esc"), key.WithHelp("q", "quit")),
 	}
@@ -81,7 +84,7 @@ func defaultKeys() keyMap {
 
 // ShortHelp implements help.KeyMap.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Next, k.New, k.Sesh, k.Buy, k.Help, k.Quit}
+	return []key.Binding{k.Next, k.New, k.Sesh, k.Buy, k.Weigh, k.Help, k.Quit}
 }
 
 // FullHelp implements help.KeyMap.
@@ -90,7 +93,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Next, k.Prev},
 		{k.Up, k.Down, k.PageUp, k.PgDown},
 		{k.Top, k.Bottom},
-		{k.New, k.Sesh, k.Buy},
+		{k.New, k.Sesh, k.Buy, k.Weigh},
 		{k.Help, k.Quit},
 	}
 }
@@ -116,6 +119,7 @@ type App struct {
 	dashboard dashboard
 	journal   journalView
 	analysis  analysisView
+	products  productsView
 	devices   devicesView
 	device    *deviceForm
 }
@@ -131,6 +135,7 @@ func New(data Data) *App {
 	a.dashboard = newDashboard()
 	a.journal = newJournalView()
 	a.analysis = newAnalysisView()
+	a.products = newProductsView()
 	a.devices = newDevicesView()
 	return a
 }
@@ -220,6 +225,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case msg.String() == "a" && a.screen == devicesScreen:
 			a.device, a.notice = newDeviceForm(nil, a), ""
 			return a, a.device.form.Init()
+		case msg.String() == "r" && a.screen != journalScreen:
+			if slug := a.weighable(); slug != "" {
+				a.entry, a.notice = newReconcileForm(slug, a), ""
+				return a, a.entry.form.Init()
+			}
+			a.notice, a.failed = "nothing on the shelf to weigh", true
+			return a, nil
 		case msg.String() == "e" && a.screen == devicesScreen:
 			if d := a.devices.Selected(a); d != nil {
 				a.device, a.notice = newDeviceForm(d, a), ""
@@ -280,6 +292,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.journal, cmd = a.journal.Update(msg, a)
 	case analysisScreen:
 		a.analysis, cmd = a.analysis.Update(msg, a)
+	case productsScreen:
+		a.products, cmd = a.products.Update(msg, a)
 	case devicesScreen:
 		a.devices, cmd = a.devices.Update(msg, a)
 	}
@@ -324,6 +338,8 @@ func (a *App) View() tea.View {
 		body = a.journal.View(a, bodyHeight)
 	case analysisScreen:
 		body = a.analysis.View(a, bodyHeight)
+	case productsScreen:
+		body = a.products.View(a, bodyHeight)
 	case devicesScreen:
 		body = a.devices.View(a, bodyHeight)
 	}
@@ -427,11 +443,35 @@ func (a *App) screenKeys() help.KeyMap {
 		return a.journal.keys(a.keys)
 	case analysisScreen:
 		return a.analysis.keys(a.keys)
+	case productsScreen:
+		return a.products.keys(a.keys)
 	case devicesScreen:
 		return a.devices.keys(a.keys)
 	default:
 		return a.keys
 	}
+}
+
+// weighable returns the product r should weigh: the one under the cursor on the
+// products screen, or otherwise whichever of the current cycle's products has
+// the most left, since that is the jar most worth checking.
+func (a *App) weighable() string {
+	if a.screen == productsScreen {
+		if r := a.products.Selected(a); r != nil {
+			return r.Slug
+		}
+	}
+	best, most := "", -1.0
+	cycle := a.data.Cycle()
+	if cycle == nil {
+		return ""
+	}
+	for _, slug := range cycle.Products {
+		if b := a.data.State.Balances[slug]; b != nil && b.Total() > most {
+			best, most = slug, b.Total()
+		}
+	}
+	return best
 }
 
 // inner returns the width available inside the frame.

--- a/pkg/tui/chart.go
+++ b/pkg/tui/chart.go
@@ -255,3 +255,7 @@ func axisLabels(t *Theme, left, right string, width int) string {
 	}
 	return t.Dim.Render(left) + strings.Repeat(" ", gap) + t.Dim.Render(right)
 }
+
+// round trims to centigrams, matching what the ledger stores and what a
+// jeweller's scale reads.
+func round(g float64) float64 { return math.Round(g*100) / 100 }

--- a/pkg/tui/dashboard.go
+++ b/pkg/tui/dashboard.go
@@ -36,6 +36,8 @@ func (d dashboard) View(a *App, height int) string {
 	sections := []string{
 		d.headline(a, cycle, stats, width),
 		"",
+		d.actions(a, width),
+		"",
 		t.Rule("Supply", width),
 		d.products(a, cycle, width),
 		"",
@@ -83,6 +85,35 @@ func (d dashboard) headline(a *App, c *ledger.Cycle, stats ledger.Stats, width i
 		lipgloss.NewStyle().Foreground(t.Level(fraction)).Render(fmt.Sprintf("%.0f%%", fraction*100)),
 	)
 	return lipgloss.JoinVertical(lipgloss.Left, cols, "", bar, scale)
+}
+
+// actions is the row of things worth doing from here, spelled out rather than
+// left in the help line. Recording the day's grind is the whole point of opening
+// this, and a key hint at the bottom of the screen is easy to never read.
+func (d dashboard) actions(a *App, width int) string {
+	t := a.theme
+	type action struct{ key, label string }
+	actions := []action{
+		{"n", "grind"},
+		{"s", "sesh"},
+		{"b", "fill"},
+		{"r", "weigh"},
+	}
+
+	cells := make([]string, 0, len(actions))
+	for _, act := range actions {
+		cells = append(cells, lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).BorderForeground(t.Line).
+			Padding(0, 1).Render(
+			lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Render(act.key)+
+				t.Dim.Render("  "+act.label)))
+	}
+	row := lipgloss.JoinHorizontal(lipgloss.Top, cells...)
+	if lipgloss.Width(row) > width {
+		// Too narrow for the boxes; the help line still carries the same keys.
+		return ""
+	}
+	return row
 }
 
 // products shows each product of this cycle as a stacked bar: what is still

--- a/pkg/tui/entry.go
+++ b/pkg/tui/entry.go
@@ -12,6 +12,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/TheDonDope/wits/pkg/journal"
+	"github.com/TheDonDope/wits/pkg/ledger"
 	"github.com/TheDonDope/wits/pkg/record"
 )
 
@@ -34,6 +35,8 @@ func (k entryKind) String() string {
 		return "Amend entry"
 	case entryUndo:
 		return "Undo entry"
+	case entryReconcile:
+		return "Weigh and reconcile"
 	default:
 		return "Grind"
 	}
@@ -210,7 +213,7 @@ func (f *entryForm) commit(a *App) (journal.Event, error) {
 	at := time.Now()
 
 	var grams float64
-	if f.kind != entryUndo {
+	if f.kind != entryUndo && f.kind != entryReconcile {
 		var err error
 		if grams, err = parseGrams(f.amount); err != nil {
 			return journal.Event{}, err
@@ -218,6 +221,13 @@ func (f *entryForm) commit(a *App) (journal.Event, error) {
 	}
 
 	switch f.kind {
+	case entryReconcile:
+		weighed, err := strconv.ParseFloat(
+			strings.Replace(strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(f.amount), "g")), ",", ".", 1), 64)
+		if err != nil {
+			return journal.Event{}, err
+		}
+		return rec.Reconcile(f.product, journal.Account(f.device), weighed, strings.TrimSpace(f.note))
 	case entryUndo:
 		if !f.confirm {
 			return journal.Event{}, errCancelled
@@ -305,4 +315,52 @@ func newUndoForm(e *journal.Event, a *App) *entryForm {
 func describe(e *journal.Event, a *App) string {
 	return fmt.Sprintf("%s  %.2f g  %s  ·  %s",
 		e.Type, e.Grams, a.data.ProductName(e.Product), e.OccurredAt.Format("Mon 02 Jan 2006"))
+}
+
+// entryReconcile makes an account agree with the scale.
+const entryReconcile entryKind = iota + 200
+
+// newReconcileForm asks what an account actually weighs.
+//
+// The ledger's own figure is put in front of the field rather than left to be
+// remembered, because the point of weighing is to compare, and a number typed
+// from memory is not a reconciliation.
+func newReconcileForm(slug string, a *App) *entryForm {
+	f := &entryForm{kind: entryReconcile, product: slug}
+	b := a.data.State.Balances[slug]
+	if b == nil {
+		b = &ledger.Balance{}
+	}
+
+	accounts := []huh.Option[string]{
+		huh.NewOption(fmt.Sprintf("Storage — ledger says %.2f g", b.Storage), string(journal.Storage)),
+		huh.NewOption(fmt.Sprintf("The tin — ledger says %.2f g", b.Stash), string(journal.Stash)),
+	}
+	if b.AVB > 0 {
+		accounts = append(accounts,
+			huh.NewOption(fmt.Sprintf("AVB — ledger says %.2f g", b.AVB), string(journal.AVB)))
+	}
+	f.device = string(journal.Storage) // reused as the account, defaulting to storage
+
+	f.form = huh.NewForm(huh.NewGroup(
+		huh.NewNote().Title(a.data.ProductName(slug)).
+			Description("Nothing in the past is edited. The difference is recorded\nas an adjustment, and the account agrees with the jar again."),
+		huh.NewSelect[string]().Title("Weigh which").Options(accounts...).Value(&f.device),
+		huh.NewInput().Title("On the scale").Description("Grams").
+			Value(&f.amount).Validate(nonNegativeGrams),
+		huh.NewInput().Title("Why").Description("Optional — spilled, unlogged, misread").Value(&f.note),
+	)).WithShowHelp(true).WithWidth(minInt(a.inner(), 72))
+	return f
+}
+
+// nonNegativeGrams accepts zero, because an empty jar is a real reading.
+func nonNegativeGrams(s string) error {
+	v, err := strconv.ParseFloat(strings.Replace(strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "g")), ",", ".", 1), 64)
+	if err != nil {
+		return fmt.Errorf("not a weight in grams")
+	}
+	if v < 0 {
+		return fmt.Errorf("a weight cannot be negative")
+	}
+	return nil
 }

--- a/pkg/tui/products.go
+++ b/pkg/tui/products.go
@@ -1,0 +1,271 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/TheDonDope/wits/pkg/catalog"
+	"github.com/TheDonDope/wits/pkg/journal"
+)
+
+// productsView lists what has been dispensed, what is left of each, and how much
+// of it has been used.
+type productsView struct {
+	cursor  int
+	allTime bool // show every product ever, not only those still held
+}
+
+func newProductsView() productsView { return productsView{} }
+
+type productKeys struct {
+	keyMap
+	Reconcile, All key.Binding
+}
+
+func (k productKeys) ShortHelp() []key.Binding {
+	return []key.Binding{k.Up, k.Down, k.Reconcile, k.All, k.Help, k.Quit}
+}
+
+func (k productKeys) FullHelp() [][]key.Binding {
+	return append(k.keyMap.FullHelp(), []key.Binding{k.Reconcile, k.All})
+}
+
+func (v productsView) keys(base keyMap) help.KeyMap {
+	return productKeys{
+		keyMap:    base,
+		Reconcile: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "weigh")),
+		All:       key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all/held")),
+	}
+}
+
+// productRow is a product with everything the screen shows about it.
+type productRow struct {
+	Product  *catalog.Product
+	Slug     string
+	Storage  float64
+	Stash    float64
+	AVB      float64
+	Ground   float64
+	Bought   float64
+	LastSeen time.Time
+}
+
+// Held is what is still on the shelf and in the tin.
+func (p productRow) Held() float64 { return round(p.Storage + p.Stash) }
+
+func (v productsView) Update(msg tea.Msg, a *App) (productsView, tea.Cmd) {
+	rows := v.rows(a)
+	if msg, ok := msg.(tea.KeyPressMsg); ok {
+		switch {
+		case key.Matches(msg, a.keys.Up):
+			v.cursor = maxInt(v.cursor-1, 0)
+		case key.Matches(msg, a.keys.Down):
+			v.cursor = minInt(v.cursor+1, maxInt(len(rows)-1, 0))
+		case key.Matches(msg, a.keys.Top):
+			v.cursor = 0
+		case key.Matches(msg, a.keys.Bottom):
+			v.cursor = maxInt(len(rows)-1, 0)
+		case msg.String() == "a":
+			v.allTime = !v.allTime
+			v.cursor = 0
+		}
+	}
+	return v, nil
+}
+
+// Selected returns the product under the cursor.
+func (v productsView) Selected(a *App) *productRow {
+	rows := v.rows(a)
+	if v.cursor < 0 || v.cursor >= len(rows) {
+		return nil
+	}
+	return &rows[v.cursor]
+}
+
+// rows folds the journal into one row per product.
+//
+// By default only products still holding something are listed: a catalog that
+// remembers four years of prescriptions is a history, not a shelf, and the shelf
+// is what a screen called Products should show first.
+func (v productsView) rows(a *App) []productRow {
+	byProduct := map[string]*productRow{}
+	get := func(slug string) *productRow {
+		if r, ok := byProduct[slug]; ok {
+			return r
+		}
+		r := &productRow{Slug: slug}
+		if a.data.Products != nil {
+			if p, err := a.data.Products.Find(slug); err == nil {
+				r.Product = p
+			}
+		}
+		byProduct[slug] = r
+		return r
+	}
+
+	for _, e := range a.data.State.Events {
+		r := get(e.Product)
+		if e.OccurredAt.After(r.LastSeen) {
+			r.LastSeen = e.OccurredAt
+		}
+		switch e.Type {
+		case journal.Purchase:
+			r.Bought = round(r.Bought + e.Grams)
+		case journal.Grind:
+			r.Ground = round(r.Ground + e.Grams)
+		}
+	}
+	for slug, b := range a.data.State.Balances {
+		r := get(slug)
+		r.Storage, r.Stash, r.AVB = b.Storage, b.Stash, b.AVB
+	}
+
+	rows := make([]productRow, 0, len(byProduct))
+	for _, r := range byProduct {
+		if !v.allTime && r.Held() <= 0 && r.AVB <= 0 {
+			continue
+		}
+		rows = append(rows, *r)
+	}
+	// Most recently touched first: what was used yesterday is what will be
+	// weighed today.
+	sort.Slice(rows, func(i, j int) bool {
+		if !rows[i].LastSeen.Equal(rows[j].LastSeen) {
+			return rows[i].LastSeen.After(rows[j].LastSeen)
+		}
+		return rows[i].Slug < rows[j].Slug
+	})
+	return rows
+}
+
+func (v productsView) View(a *App, height int) string {
+	t := a.theme
+	width := a.inner()
+	rows := v.rows(a)
+
+	if len(rows) == 0 {
+		message := "Nothing on the shelf.\n\nRecord a prescription fill with "
+		if v.allTime {
+			message = "No products yet.\n\nRecord a prescription fill with "
+		}
+		return lipgloss.NewStyle().Padding(1, 1).Render(
+			t.Subtitle.Render(message) + t.Key.Render("b") + t.Subtitle.Render(" or `wits buy`."))
+	}
+	if v.cursor >= len(rows) {
+		v.cursor = len(rows) - 1
+	}
+
+	scope := "on the shelf"
+	if v.allTime {
+		scope = "every product ever dispensed"
+	}
+	head := lipgloss.JoinHorizontal(lipgloss.Left,
+		t.Label.Width(34).Render("PRODUCT"),
+		t.Label.Width(10).Render("THC/CBD"),
+		t.Label.Width(10).Align(lipgloss.Right).Render("STORAGE"),
+		t.Label.Width(9).Align(lipgloss.Right).Render("TIN"),
+		t.Label.Width(9).Align(lipgloss.Right).Render("AVB"),
+		t.Label.Width(11).Align(lipgloss.Right).Render("GROUND"),
+	)
+
+	lines := []string{t.Dim.Render(fmt.Sprintf("%s · %d", scope, len(rows))), "", head}
+	for i, r := range rows {
+		lines = append(lines, v.line(a, r, i == v.cursor))
+		if i == v.cursor {
+			lines = append(lines, v.detail(a, r, width))
+		}
+	}
+	return lipgloss.NewStyle().Padding(0, 1).Render(
+		clip(lipgloss.JoinVertical(lipgloss.Left, lines...), height-1))
+}
+
+// line renders one product as a row.
+func (v productsView) line(a *App, r productRow, selected bool) string {
+	t := a.theme
+	name := truncate(a.data.ProductName(r.Slug), 32)
+	label := t.Value.Width(32).Render(name)
+	marker := "  "
+	if selected {
+		marker = lipgloss.NewStyle().Foreground(t.Accent).Render("│ ")
+		label = lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Width(32).Render(name)
+	}
+
+	potency := "—"
+	if r.Product != nil && r.Product.THC > 0 {
+		potency = fmt.Sprintf("%g/%g", r.Product.THC, r.Product.CBD)
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left,
+		marker, label,
+		t.Dim.Width(10).Render(potency),
+		grams(t, r.Storage, t.StorageC, 10),
+		grams(t, r.Stash, t.StashC, 9),
+		grams(t, r.AVB, t.AVBC, 9),
+		t.Dim.Width(11).Align(lipgloss.Right).Render(fmt.Sprintf("%.2f g", r.Ground)),
+	)
+}
+
+// grams renders an amount in an account's colour, dimmed when it is empty so
+// that a column of zeroes does not compete with the figures that matter.
+func grams(t *Theme, g float64, colour tint, width int) string {
+	style := lipgloss.NewStyle().Foreground(colour)
+	if g <= 0 {
+		style = t.Dim
+	}
+	return style.Width(width).Align(lipgloss.Right).Render(fmt.Sprintf("%.2f g", g))
+}
+
+// detail is the block under the selected product.
+func (v productsView) detail(a *App, r productRow, width int) string {
+	t := a.theme
+
+	var facts []string
+	if r.Product != nil {
+		if r.Product.Manufacturer != "" {
+			facts = append(facts, r.Product.Manufacturer)
+		}
+		if r.Product.Cultivar != "" {
+			facts = append(facts, r.Product.Cultivar)
+		}
+	}
+	if !r.LastSeen.IsZero() {
+		facts = append(facts, "last used "+humanDay(r.LastSeen, a.data.Now))
+	}
+
+	// The bar is what is still held against what was dispensed, which is what
+	// the label beside it says. Filling it from grams ground instead would
+	// disagree with its own caption whenever anything was adjusted or seshed.
+	remaining := 0.0
+	if r.Bought > 0 {
+		remaining = clamp(r.Held()/r.Bought, 0, 1)
+	}
+	bar := Gauge(maxInt(width-46, 10), remaining, t.Level(remaining), t.Dim)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		"  "+t.Dim.Render(strings.Join(facts, " · ")),
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			"  ", bar, " ",
+			t.Dim.Render(fmt.Sprintf("%.2f g of %.2f g dispensed still held", r.Held(), r.Bought)),
+		),
+		"  "+t.Dim.Render("press ")+t.Key.Render("r")+t.Dim.Render(" to weigh it and make the ledger agree"),
+		"",
+	)
+}
+
+// humanDay says today or yesterday where it can, and a date otherwise.
+func humanDay(d, now time.Time) string {
+	switch daysBetween(d, now) {
+	case 0:
+		return "today"
+	case 1:
+		return "yesterday"
+	default:
+		return d.Format("02 Jan 2006")
+	}
+}

--- a/pkg/tui/products_test.go
+++ b/pkg/tui/products_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TheDonDope/wits/pkg/journal"
+	"github.com/TheDonDope/wits/pkg/record"
+)
+
+// shelved returns an app holding two products, one of them used up.
+func shelved(t *testing.T) *App {
+	t.Helper()
+	app := liveApp(t)
+	rec := record.New(app.data.Repo, app.data.Products, app.data.Devices, app.data.State)
+
+	_, _, _, err := rec.Buy("Cannamedical 28/1 Lemon Cookie", 10, time.Now().AddDate(0, 0, -2))
+	require.NoError(t, err)
+	_, err = rec.Grind("lemon", 10, time.Now().AddDate(0, 0, -1))
+	require.NoError(t, err)
+	_, err = rec.Session("lemon", 10, time.Now().AddDate(0, 0, -1), "", 0, "")
+	require.NoError(t, err)
+	_, err = rec.Grind("wedding", 2, time.Now())
+	require.NoError(t, err)
+
+	app.data, err = Load(app.data.Repo)
+	require.NoError(t, err)
+	return app
+}
+
+func TestProductsScreen(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+	var m tea.Model = app
+
+	out := stripANSI(m.View().Content)
+
+	assert.Contains(t, out, "Enua 22/1 Wedding Cake", "Should name the product")
+	assert.Contains(t, out, "22/1", "Should show its potency")
+	assert.Contains(t, out, "18.00 g", "Should show what is in storage")
+	assert.Contains(t, out, "2.00 g", "and what is in the tin")
+	assert.Contains(t, out, "on the shelf", "Should say what it is listing")
+}
+
+func TestProductsListsOnlyWhatIsHeld(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+	var m tea.Model = app
+
+	held := stripANSI(m.View().Content)
+	assert.NotContains(t, held, "Lemon Cookie",
+		"A product with nothing left is history, not shelf")
+	assert.Contains(t, held, "on the shelf · 1", "Should count only what is held")
+
+	// `a` widens it to everything ever dispensed.
+	m, _ = send(m, tea.KeyPressMsg{Code: 'a', Text: "a"})
+	all := stripANSI(m.View().Content)
+	assert.Contains(t, all, "Lemon Cookie", "Should bring the used-up product back")
+	assert.Contains(t, all, "every product ever dispensed", "and say that is what it is showing")
+}
+
+func TestProductsGaugeAgreesWithItsCaption(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+
+	rows := app.products.rows(app)
+	require.NotEmpty(t, rows)
+	r := rows[0]
+
+	// The bar is filled from held-over-dispensed, which is what the text beside
+	// it states. Filling it from grams ground would disagree with itself as soon
+	// as anything is seshed or adjusted.
+	assert.InDelta(t, 20.0, r.Bought, 0.001)
+	assert.InDelta(t, 20.0, r.Held(), 0.001, "nothing has left the product yet, only moved tin-wards")
+	assert.InDelta(t, 2.0, r.Ground, 0.001, "though 2 g has been ground")
+}
+
+func TestProductsCursorAndSelection(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+	app.products.allTime = true
+	var m tea.Model = app
+
+	first := app.products.Selected(app)
+	require.NotNil(t, first)
+
+	m, _ = send(m, tea.KeyPressMsg{Code: 'j', Text: "j"})
+	second := app.products.Selected(app)
+	require.NotNil(t, second)
+	assert.NotEqual(t, first.Slug, second.Slug, "Should move to the next product")
+
+	for i := 0; i < 8; i++ {
+		m, _ = send(m, tea.KeyPressMsg{Code: 'k', Text: "k"})
+	}
+	assert.Equal(t, first.Slug, app.products.Selected(app).Slug, "Should stop at the top")
+}
+
+func TestProductsEmpty(t *testing.T) {
+	app := New(emptyData(t))
+	app.screen = productsScreen
+	var m tea.Model = app
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 96, Height: 30})
+
+	out := stripANSI(m.View().Content)
+
+	assert.Contains(t, out, "Nothing on the shelf", "Should say so rather than show an empty table")
+	assert.Contains(t, out, "wits buy", "and say what to do about it")
+}
+
+func TestWeighPicksTheFullestJarOffTheProductsScreen(t *testing.T) {
+	app := shelved(t)
+	app.screen = dashboardScreen
+
+	// Away from the products screen there is no cursor, so it offers the jar
+	// with the most left — the one most worth checking.
+	slug := app.weighable()
+
+	assert.Equal(t, "enua-wedding-cake", slug, "Should pick the fullest jar of the cycle")
+}
+
+func TestReconcileFromTheInterface(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+	var m tea.Model = app
+
+	before := app.data.State.Balances["enua-wedding-cake"].Storage
+	require.InDelta(t, 18.0, before, 0.001)
+
+	m, _ = send(m, tea.KeyPressMsg{Code: 'r', Text: "r"})
+	require.NotNil(t, app.entry, "r should open the weighing form")
+
+	// Storage is preselected; type what the scale says and submit.
+	m, _ = send(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = typeText(m, "17.6")
+	_, msgs := confirmThrough(m, 6)
+
+	done, ok := findDone(msgs)
+	require.True(t, ok, "Should report the outcome, got %v", msgs)
+	require.NoError(t, done.err)
+
+	assert.Equal(t, journal.Adjust, done.event.Type, "Should record an adjustment")
+	assert.InDelta(t, 0.40, done.event.Grams, 0.001, "of the difference, not the weight")
+	assert.InDelta(t, 17.6, app.data.State.Balances["enua-wedding-cake"].Storage, 0.001,
+		"and storage should now agree with the scale")
+}
+
+func TestDashboardShowsQuickActions(t *testing.T) {
+	app := shelved(t)
+	app.screen = dashboardScreen
+	var m tea.Model = app
+
+	out := stripANSI(m.View().Content)
+
+	for _, want := range []string{"grind", "sesh", "fill", "weigh"} {
+		assert.Contains(t, out, want, "the home view should offer %q without reading the help line", want)
+	}
+}
+
+func TestQuickActionsFoldAwayWhenNarrow(t *testing.T) {
+	app := shelved(t)
+	app.screen = dashboardScreen
+	var m tea.Model = app
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+
+	out := stripANSI(m.View().Content)
+
+	for _, line := range strings.Split(out, "\n") {
+		// Display cells, not bytes: the box-drawing characters are three bytes each.
+		assert.LessOrEqual(t, lipgloss.Width(line), 41,
+			"the boxes should not push the frame sideways: %q", line)
+	}
+}

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -181,3 +181,11 @@ func TestEventLineHidesAMeaninglessTime(t *testing.T) {
 	assert.Contains(t, stripANSI(th.EventLine(evening, "X", 80, false)), "21:30",
 		"A real time should be shown")
 }
+
+// emptyData is a repository with nothing in it.
+func emptyData(t *testing.T) Data {
+	t.Helper()
+	return Data{Workspace: &workspace.Workspace{
+		Products: &catalog.Catalog{}, Devices: &catalog.Devices{}, State: ledger.Fold(nil),
+	}, Now: time.Now()}
+}


### PR DESCRIPTION
## Description

A products screen, quick actions on the home view, and the piece that was missing from the ledger: reconciling it against a scale.

### Reconciliation

Ledgers drift. A little is spilled, a session goes unlogged, a scale is misread. Editing the past to hide it would be a lie — nobody knows which entry was wrong. So the difference between what the ledger believes an account holds and what it actually weighs is **recorded**, as an adjustment. An adjustment is a transfer like any other, so the accounts still balance afterwards and mass is still conserved.

```console
$ wits reconcile wedding-cake 17.6 --dry-run
storage holds 18.00g by the ledger and 17.60g on the scale: -0.40g

$ wits reconcile wedding-cake 17.6 --reason "spilled on the desk"
[21ee6ae] adjusted 0.40g out of storage, now 17.60g
```

`--stash` weighs the tin, `--avb` the already vaped bud. `consumed` is refused: it is what has gone through a device on its way to becoming AVB, and there is no jar of it to put on a scale.

Two decisions worth flagging:

- **Weighing to zero is allowed.** An empty jar is a real reading, and refusing it would mean the one case you most want to record is the one you cannot.
- **Weighing to what the ledger already says is refused**, rather than recorded as a zero-gram entry. Nothing happened; the log should not claim otherwise.

The entry notes both figures — `reconciled storage: 17.60 g weighed, 18.00 g expected` — because the entry itself only carries the difference, and a difference without its baseline is unreadable a year later.

### The products screen

What is actually on the shelf: storage, tin, AVB, grams ground, potency, and how much of the fill is still held.

```text
 PRODUCT                           THC/CBD      STORAGE      TIN      AVB     GROUND
 │ Enua 22/1 Wedding Cake          22/1         16.00 g   3.50 g   0.00 g     3.50 g
   Enua · Wedding Cake · last used today
   ██████████████████████████████████████████████████▊─ 19.50 g of 20.00 g dispensed still held
   press r to weigh it and make the ledger agree
```

Held products by default, everything ever dispensed on `a` — a catalog that remembers four years of prescriptions is a history, and the shelf is what a screen called Products should lead with. Sorted by most recently touched, because what was used yesterday is what gets weighed today.

### The home view

```text
 ╭──────────╮╭─────────╮╭─────────╮╭──────────╮
 │ n  grind ││ s  sesh ││ b  fill ││ r  weigh │
 ╰──────────╯╰─────────╯╰─────────╯╰──────────╯
```

Recording the day's grind is the whole reason to open this, and a key hint along the bottom is easy to never read. The boxes fold away when the terminal is too narrow for them; the help line still carries the same keys.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] `go test ./... -race`, `go vet`, `gofmt` clean; builds for Linux and Windows
- [x] Reconciliation covered both directions, to zero, to no difference, on each account, with and without a reason, and that mass still balances afterwards
- [x] The command covered including `--dry-run` writing nothing and `--stash --avb` together being refused rather than one silently winning
- [x] The screen covered: listing, held-versus-all, cursor bounds, the empty shelf, and reconciling end to end through the form with the entry landing in the journal

Two defects caught while building rather than after:

- **The screen's gauge disagreed with its own caption.** It was filled from grams *ground* while the text beside it read grams *held* — a 15-point gap on a product with anything seshed or adjusted. Found by rendering it and reading the numbers, not by a test.
- **The narrow-terminal test measured bytes, not display cells.** Box-drawing characters are three bytes each, so it failed on lines that fit perfectly well. Same mistake I made on an earlier gauge test; `lipgloss.Width` is the measure that matters.

**Test Configuration**: Go 1.26.5, Linux

## Notes for the reviewer

The products screen lists and weighs but cannot yet correct a parsed product name, or split the two products the slug merged. Both are on the roadmap.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
