### PR TITLE
feat: short product handles, editing a product, and completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,36 @@ wits init .
 
 Record a fill, then use it:
 
+```console
+$ wits buy "Enua 22/1 Wedding Cake" 20g
+New product Enua 22/1 Wedding Cake — refer to it as wcake
+[029efe8] purchase 20.00g wcake into storage
+```
+
+Every product gets a short handle — three to five characters, made up from the
+cultivar and guaranteed not to be one keystroke from another, since references
+are resolved by prefix. Pass `--slug lemon` to choose your own. It is settled
+when the product first appears and never changes, because it is the name every
+later entry refers to.
+
 ```sh
-wits buy "Enua 22/1 Wedding Cake" 20g
-wits grind wedding-cake 0.75
-wits sesh wedding-cake 0.3 --device volcano --temp 185
+wits grind wcake 0.75
+wits sesh wcake 0.3 --device volcano --temp 185
 wits status
 ```
+
+Tab completion offers the handles, with the full name and how much is left
+beside each — and only the ones the command can act on, so `sesh` offers what is
+in a tin rather than everything ever dispensed:
+
+```console
+$ wits grind <TAB>
+lcook   10.00 g · Cannamedical 28/1 Lemon Cookie
+mac1    15.00 g · Cantourage 25/1 MAC1+
+wcake   18.00 g · Enua 22/1 Wedding Cake
+```
+
+Install it with `wits completion bash` (or `zsh`, `fish`).
 
 Anything can be backdated with `--date 2026-07-29`, which is what makes a
 forgotten evening loggable the next morning without pretending it was entered
@@ -96,7 +120,7 @@ too — `n` to grind, `s` for a session, `b` for a fill, `r` to weigh.
 | | |
 | --- | --- |
 | `wits init [dir]` | Create a repository |
-| `wits buy <product> <amount>` | Record a prescription fill into storage |
+| `wits buy <product> <amount>` | Record a prescription fill, `--slug` to name it |
 | `wits grind <product> <amount>` | Move product from storage into its tin |
 | `wits sesh <product> <amount>` | Record a session, drawing on the tin |
 | `wits status` | What is left, and how long it will last |
@@ -122,7 +146,8 @@ wits log --oneline -n 1
 wits revert 8297238 --reason "misread the scale"
 ```
 
-In the interface, `e` amends an amount and `d` undoes an entry. The log shows what
+On the products screen, `e` corrects a name and `r` weighs a jar. In the journal,
+`e` amends an amount and `d` undoes an entry. The log shows what
 currently stands; `v` reveals the corrections behind it.
 
 ## When the ledger and the scale disagree

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,6 +153,12 @@ ground, with the potency and how much of the fill is still held. It lists what i
 held by default and everything ever dispensed on `a`, because a catalog
 remembering four years of prescriptions is a history rather than a shelf.
 
+Every product gets a short handle when it is first bought — three to five
+characters from the cultivar, never one keystroke from another, since references
+resolve by prefix. `--slug` chooses one by hand. It is fixed once and never
+changes: it is the name every entry refers to, so `e` on the products screen
+corrects what a product is *called*, not which product it *is*.
+
 `wits reconcile`, and `r` in the interface, record the difference between what
 the ledger believes an account holds and what it actually weighs. Nothing in the
 past is edited: the difference becomes an adjustment, which is a transfer like
@@ -178,11 +184,10 @@ range is checked when it is typed rather than later when a session is refused.
   recorded grinding. Nothing was invented to fill that gap, so the stash balance
   of a product recurring across cycles reads high until it is worked down.
 
-### 🔹 Editing a product, and splitting ones the slug merged
+### 🔹 Splitting products the slug merged
 
 - **Status**: Planned
-- The products screen lists and weighs; it cannot yet correct a parsed name.
-- `Slugify` drops the THC ratio, so the same cultivar from one manufacturer at two
+- The importer's `Slugify` drops the THC ratio, so the same cultivar from one manufacturer at two
   potencies becomes one product. The importer reports these rather than doing it
   quietly, but there is no way to split them afterwards.
 

--- a/cmd/wits/commands/buy.go
+++ b/cmd/wits/commands/buy.go
@@ -6,7 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var buyDate string
+var (
+	buyDate string
+	buySlug string
+)
 
 // Buy is the `wits buy` command.
 var Buy = &cobra.Command{
@@ -18,7 +21,8 @@ var Buy = &cobra.Command{
 		"follows the usual convention; anything it gets wrong can be corrected in\n" +
 		".wits/products.yml.",
 	Example: "  wits buy \"Enua 22/1 Wedding Cake\" 20g\n" +
-		"  wits buy \"Cannamedical 28/1 Lemon Cookie\" 10g --date 2026-07-09",
+		"  wits buy \"Cannamedical 28/1 Lemon Cookie\" 10g --slug lemon\n" +
+		"  wits buy \"Cantourage 25/1 MAC1+\" 20g --date 2026-07-09",
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		s, err := open()
@@ -33,12 +37,15 @@ var Buy = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		e, product, added, err := s.Recorder.Buy(args[0], grams, at)
+		e, product, added, err := s.Recorder.Buy(args[0], buySlug, grams, at)
 		if err != nil {
 			return err
 		}
 		if added {
-			fmt.Fprintf(cmd.OutOrStdout(), "New product %s (%s)\n", product.Slug, product.Name)
+			// The slug is what every later command refers to, so it is said
+			// plainly rather than left to be discovered in products.yml.
+			fmt.Fprintf(cmd.OutOrStdout(), "New product %s — refer to it as %s\n",
+				product.Name, product.Slug)
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "[%s] purchase %.2fg %s into storage\n",
 			shortHash(e.Hash), e.Grams, product.Slug)
@@ -48,4 +55,5 @@ var Buy = &cobra.Command{
 
 func init() {
 	Buy.Flags().StringVar(&buyDate, "date", "", "the date the fill happened, defaults to now")
+	Buy.Flags().StringVar(&buySlug, "slug", "", "what to call it from now on; made up if not given")
 }

--- a/cmd/wits/commands/commands.go
+++ b/cmd/wits/commands/commands.go
@@ -8,10 +8,14 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
+	"github.com/TheDonDope/wits/pkg/journal"
 	"github.com/TheDonDope/wits/pkg/workspace"
 )
 
@@ -63,4 +67,59 @@ func shortHash(h string) string {
 		return h[:7]
 	}
 	return h
+}
+
+// completeProduct offers the products that hold something in the given account,
+// so tab completion on a grind offers what can actually be ground and not four
+// years of empty jars.
+//
+// Each slug is offered with its display name after a tab, which is the shape a
+// shell shows as a description beside the candidate.
+func completeProduct(account journal.Account) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, prefix string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		s, err := open()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var out []string
+		for _, slug := range s.State.Products() {
+			if !strings.HasPrefix(slug, prefix) {
+				continue
+			}
+			have := s.Recorder.Available(slug, account)
+			if account != "" && have <= 0 {
+				continue
+			}
+			out = append(out, fmt.Sprintf("%s\t%.2f g · %s", slug, have, s.ProductName(slug)))
+		}
+		sort.Strings(out)
+		return out, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// completeEntry offers the recent entries by their abbreviated hash, for the
+// commands that take one.
+func completeEntry(_ *cobra.Command, args []string, prefix string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	s, err := open()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	events := s.State.Events
+	var out []string
+	for i := len(events) - 1; i >= 0 && len(out) < 40; i-- {
+		e := events[i]
+		short := shortHash(e.Hash)
+		if !strings.HasPrefix(short, prefix) {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s\t%s %.2f g %s on %s",
+			short, e.Type, e.Grams, e.Product, e.OccurredAt.Format(time.DateOnly)))
+	}
+	return out, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/wits/commands/commands_test.go
+++ b/cmd/wits/commands/commands_test.go
@@ -71,7 +71,8 @@ func TestBuyAndGrind(t *testing.T) {
 
 		out, err := run(t, dir, Buy, "Enua 22/1 Wedding Cake", "20g", "--date", "2026-07-01")
 		require.NoError(t, err)
-		assert.Contains(t, out, "New product enua-wedding-cake", "Should register the product")
+		assert.Contains(t, out, "refer to it as wcake",
+			"Should register the product and say what to call it")
 
 		out, err = run(t, dir, Grind, "wedding", "0.75", "--date", "2026-07-02")
 		require.NoError(t, err)
@@ -156,7 +157,7 @@ func TestLogCommand(t *testing.T) {
 		out, err := run(t, dir, Log, "--product", "wedding")
 
 		require.NoError(t, err)
-		assert.Contains(t, out, "enua-wedding-cake", "Should show the product's events")
+		assert.Contains(t, out, "wcake", "Should show the product's events")
 	})
 }
 

--- a/cmd/wits/commands/grind.go
+++ b/cmd/wits/commands/grind.go
@@ -19,7 +19,8 @@ var Grind = &cobra.Command{
 		"name, so a daily entry stays short.",
 	Example: "  wits grind wedding-cake 0.75\n" +
 		"  wits grind lemon 1.2 --date 2026-07-29",
-	Args: cobra.ExactArgs(2),
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeProduct(journal.Storage),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		s, err := open()
 		if err != nil {

--- a/cmd/wits/commands/import_test.go
+++ b/cmd/wits/commands/import_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xuri/excelize/v2"
+
+	"github.com/TheDonDope/wits/pkg/journal"
 )
 
 // workbook writes a small tracking spreadsheet, laid out like the real one:
@@ -123,5 +126,53 @@ func TestImportCommand(t *testing.T) {
 	t.Run("MissingFile", func(t *testing.T) {
 		_, err := run(t, repository(t), Import, filepath.Join(t.TempDir(), "nope.xlsx"))
 		assert.Error(t, err, "Should report a workbook it cannot open")
+	})
+}
+
+func TestCompletion(t *testing.T) {
+	dir := repository(t)
+	_, err := run(t, dir, Buy, "Enua 22/1 Wedding Cake", "20g")
+	require.NoError(t, err)
+	_, err = run(t, dir, Buy, "Cannamedical 28/1 Lemon Cookie", "10g")
+	require.NoError(t, err)
+	_, err = run(t, dir, Grind, "wcake", "2")
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	t.Run("GrindOffersAnythingInStorage", func(t *testing.T) {
+		out, _ := completeProduct(journal.Storage)(nil, nil, "")
+
+		require.Len(t, out, 2, "both products have storage")
+		assert.Contains(t, strings.Join(out, "\n"), "wcake", "Should offer the slug")
+		assert.Contains(t, strings.Join(out, "\n"), "Enua 22/1 Wedding Cake",
+			"and the name beside it, since a slug alone is not recognisable")
+	})
+
+	t.Run("SeshOffersOnlyWhatIsInATin", func(t *testing.T) {
+		out, _ := completeProduct(journal.Stash)(nil, nil, "")
+
+		require.Len(t, out, 1, "only one product has been ground")
+		assert.Contains(t, out[0], "wcake",
+			"Should not offer a product that cannot be seshed")
+	})
+
+	t.Run("FiltersByWhatHasBeenTyped", func(t *testing.T) {
+		out, _ := completeProduct(journal.Storage)(nil, nil, "l")
+
+		require.Len(t, out, 1)
+		assert.Contains(t, out[0], "lcook", "Should narrow to the prefix")
+	})
+
+	t.Run("OffersNothingForTheSecondArgument", func(t *testing.T) {
+		out, _ := completeProduct(journal.Storage)(nil, []string{"wcake"}, "")
+
+		assert.Empty(t, out, "The amount is not a product")
+	})
+
+	t.Run("EntriesCompleteByHash", func(t *testing.T) {
+		out, _ := completeEntry(nil, nil, "")
+
+		require.NotEmpty(t, out)
+		assert.Contains(t, out[0], "grind", "Should describe the entry, newest first")
 	})
 }

--- a/cmd/wits/commands/reconcile.go
+++ b/cmd/wits/commands/reconcile.go
@@ -30,7 +30,8 @@ var Reconcile = &cobra.Command{
 	Example: "  wits reconcile wedding-cake 17.6\n" +
 		"  wits reconcile wedding-cake 1.75 --stash --reason \"spilled on the desk\"\n" +
 		"  wits reconcile wedding-cake 17.6 --dry-run",
-	Args: cobra.ExactArgs(2),
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeProduct(""),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		s, err := open()
 		if err != nil {

--- a/cmd/wits/commands/revert.go
+++ b/cmd/wits/commands/revert.go
@@ -20,7 +20,8 @@ var Revert = &cobra.Command{
 		"The entry is named by its hash, abbreviated as `wits log` shows it.",
 	Example: "  wits revert 8297238\n" +
 		"  wits revert 8297238 --reason \"weighed the jar, not the herb\"",
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeEntry,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		s, err := open()
 		if err != nil {

--- a/cmd/wits/commands/sesh.go
+++ b/cmd/wits/commands/sesh.go
@@ -30,7 +30,8 @@ var Sesh = &cobra.Command{
 		"benzene.",
 	Example: "  wits sesh wedding-cake 0.3 --device volcano --temp 185\n" +
 		"  wits sesh lemon 0.2 --date 2026-07-29",
-	Args: cobra.ExactArgs(2),
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeProduct(journal.Stash),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		s, err := open()
 		if err != nil {

--- a/cmd/wits/main.go
+++ b/cmd/wits/main.go
@@ -44,7 +44,8 @@ var (
 )
 
 func init() {
-	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+	// The completion command stays visible: tab completion offers the product
+	// slugs, which is most of what makes short slugs worth having.
 	rootCmd.AddCommand(
 		commands.Init,
 		commands.Bundle,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -189,3 +189,168 @@ func parseFloat(s string) float64 {
 	}
 	return v
 }
+
+// Handle length bounds for a generated slug.
+const (
+	minHandle = 3
+	maxHandle = 5
+)
+
+// validHandle is what a slug given by hand is allowed to look like. Slugs are
+// typed daily and matched by prefix, so they stay lowercase and free of
+// anything that needs quoting on a command line.
+var validHandle = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,23}$`)
+
+// ErrBadSlug is returned for a slug that cannot be used.
+var ErrBadSlug = errors.New("a slug must be 2 to 24 characters of lowercase letters, digits or dashes")
+
+// CheckSlug reports whether a slug given by hand can be used.
+func CheckSlug(slug string) error {
+	if !validHandle.MatchString(slug) {
+		return fmt.Errorf("%w: %q", ErrBadSlug, slug)
+	}
+	return nil
+}
+
+// NewHandle returns a short, typeable slug for a product: three to five
+// characters, and not one already taken.
+//
+// The long form derived from a display name — enua-wedding-cake — is precise but
+// nobody wants to type it every evening. This produces something closer to what
+// a person would abbreviate it to themselves, preferring the cultivar over the
+// manufacturer, because the cultivar is what distinguishes one jar from the next.
+func NewHandle(p *Product, existing []string) string {
+	taken := func(candidate string) bool {
+		for _, slug := range existing {
+			// Not merely equal: a handle that is a prefix of another, or has
+			// another as its prefix, is one keystroke from the wrong jar, and
+			// references are resolved by prefix. wcake and wcak must not both
+			// exist.
+			if strings.HasPrefix(candidate, slug) || strings.HasPrefix(slug, candidate) {
+				return true
+			}
+		}
+		return false
+	}
+	basis := p.Cultivar
+	if strings.TrimSpace(basis) == "" {
+		basis = p.Name
+	}
+	words := handleWords(basis)
+	if full := handleWords(p.Name); len(words) == 0 {
+		words = full
+	} else if len(words) == 1 && len(words[0]) < minHandle {
+		// One short word on its own has nothing to shorten; the rest of the
+		// name is what is left to borrow from.
+		words = append(words, full...)
+	}
+
+	for _, candidate := range handleCandidates(words) {
+		if len(candidate) >= minHandle && len(candidate) <= maxHandle && !taken(candidate) {
+			return candidate
+		}
+	}
+	// Everything memorable was taken, so number it: the point is that it is
+	// short and unique, and a person who has three Wedding Cakes open at once
+	// needs telling them apart more than they need a mnemonic.
+	stem := "p"
+	if len(words) > 0 {
+		stem = words[0]
+	}
+	// Shorter stems first within each number, so the digit stays visible:
+	// wedd is taken, so wed2 rather than wedd2 — which the prefix rule would
+	// reject anyway — and certainly rather than wed10.
+	for n := 2; ; n++ {
+		suffix := strconv.Itoa(n)
+		for keep := maxHandle - len(suffix); keep >= minHandle-len(suffix); keep-- {
+			if keep <= 0 || keep > len(stem) {
+				continue
+			}
+			candidate := stem[:keep] + suffix
+			if len(candidate) >= minHandle && len(candidate) <= maxHandle && !taken(candidate) {
+				return candidate
+			}
+		}
+	}
+}
+
+// handleCandidates offers abbreviations in the order a person would reach for
+// them: the initials, then a contraction, then the beginning of the first word.
+func handleCandidates(words []string) []string {
+	if len(words) == 0 {
+		return nil
+	}
+	var out []string
+
+	initials := ""
+	for _, w := range words {
+		initials += w[:1]
+	}
+	out = append(out, initials)
+
+	if len(words) > 1 {
+		last := words[len(words)-1]
+		// One letter of the first word and the head of the last: "Wedding Cake"
+		// reads as wcake, which is what it gets called anyway.
+		for _, n := range []int{4, 3, 2} {
+			if len(last) >= n {
+				out = append(out, words[0][:1]+last[:n])
+			}
+		}
+	}
+	// Four characters before five: "muns" is how a word gets shortened by hand,
+	// "munso" is how a field gets truncated by a program.
+	for _, n := range []int{4, maxHandle, minHandle} {
+		if len(words[0]) >= n {
+			out = append(out, words[0][:n])
+		}
+	}
+	// A word too short to abbreviate borrows a letter rather than a number,
+	// which would otherwise read as though something had collided.
+	if len(words[0]) < minHandle {
+		if len(words) > 1 {
+			out = append(out, words[0]+words[1])
+		}
+		for _, w := range words[1:] {
+			out = append(out, words[0]+w[:1])
+		}
+	}
+	return out
+}
+
+// handleWords reduces a name to lowercase alphanumeric words, dropping the
+// THC/CBD ratio and anything too short to abbreviate from.
+func handleWords(s string) []string {
+	s = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(s), "(g)"))
+	s = ratio.ReplaceAllString(s, " ")
+	var words []string
+	for _, w := range strings.FieldsFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	}) {
+		if w != "" {
+			words = append(words, w)
+		}
+	}
+	return words
+}
+
+// Handles returns every slug in the catalog.
+func (c *Catalog) Handles() []string {
+	out := make([]string, 0, len(c.Products))
+	for _, p := range c.Products {
+		out = append(out, p.Slug)
+	}
+	return out
+}
+
+// Taken reports whether a slug is already in the catalog. Unlike the check a
+// generated handle is held to, this is exact: a slug given by hand is the
+// caller's business as long as it is not literally somebody else's.
+func (c *Catalog) Taken(slug string) bool {
+	for _, p := range c.Products {
+		if p.Slug == slug {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -220,46 +220,66 @@ func CheckSlug(slug string) error {
 // a person would abbreviate it to themselves, preferring the cultivar over the
 // manufacturer, because the cultivar is what distinguishes one jar from the next.
 func NewHandle(p *Product, existing []string) string {
-	taken := func(candidate string) bool {
+	free := notNear(existing)
+	words := handleBasis(p)
+
+	for _, candidate := range handleCandidates(words) {
+		if len(candidate) >= minHandle && len(candidate) <= maxHandle && free(candidate) {
+			return candidate
+		}
+	}
+	return numberedHandle(words, free)
+}
+
+// notNear reports whether a candidate is far enough from every slug already in
+// use.
+//
+// Not merely different: a handle that is a prefix of another, or has another as
+// its prefix, is one keystroke from the wrong jar, and references are resolved
+// by prefix. wcake and wcak must not both exist.
+func notNear(existing []string) func(string) bool {
+	return func(candidate string) bool {
 		for _, slug := range existing {
-			// Not merely equal: a handle that is a prefix of another, or has
-			// another as its prefix, is one keystroke from the wrong jar, and
-			// references are resolved by prefix. wcake and wcak must not both
-			// exist.
 			if strings.HasPrefix(candidate, slug) || strings.HasPrefix(slug, candidate) {
-				return true
+				return false
 			}
 		}
-		return false
+		return true
 	}
+}
+
+// handleBasis reduces a product to the words worth abbreviating, preferring the
+// cultivar, since that is what distinguishes one jar from the next.
+func handleBasis(p *Product) []string {
 	basis := p.Cultivar
 	if strings.TrimSpace(basis) == "" {
 		basis = p.Name
 	}
 	words := handleWords(basis)
-	if full := handleWords(p.Name); len(words) == 0 {
-		words = full
-	} else if len(words) == 1 && len(words[0]) < minHandle {
+	full := handleWords(p.Name)
+	switch {
+	case len(words) == 0:
+		return full
+	case len(words) == 1 && len(words[0]) < minHandle:
 		// One short word on its own has nothing to shorten; the rest of the
 		// name is what is left to borrow from.
-		words = append(words, full...)
+		return append(words, full...)
+	default:
+		return words
 	}
+}
 
-	for _, candidate := range handleCandidates(words) {
-		if len(candidate) >= minHandle && len(candidate) <= maxHandle && !taken(candidate) {
-			return candidate
-		}
-	}
-	// Everything memorable was taken, so number it: the point is that it is
-	// short and unique, and a person who has three Wedding Cakes open at once
-	// needs telling them apart more than they need a mnemonic.
+// numberedHandle is the last resort, when everything memorable is taken. The
+// point is then to be short and unique: somebody with three Wedding Cakes open
+// at once needs to tell them apart more than they need a mnemonic.
+//
+// Shorter stems come first within each number so the digit stays visible: wedd
+// being taken gives wed2, not wedd2 — which the nearness rule rejects anyway.
+func numberedHandle(words []string, free func(string) bool) string {
 	stem := "p"
 	if len(words) > 0 {
 		stem = words[0]
 	}
-	// Shorter stems first within each number, so the digit stays visible:
-	// wedd is taken, so wed2 rather than wedd2 — which the prefix rule would
-	// reject anyway — and certainly rather than wed10.
 	for n := 2; ; n++ {
 		suffix := strconv.Itoa(n)
 		for keep := maxHandle - len(suffix); keep >= minHandle-len(suffix); keep-- {
@@ -267,7 +287,7 @@ func NewHandle(p *Product, existing []string) string {
 				continue
 			}
 			candidate := stem[:keep] + suffix
-			if len(candidate) >= minHandle && len(candidate) <= maxHandle && !taken(candidate) {
+			if len(candidate) >= minHandle && len(candidate) <= maxHandle && free(candidate) {
 				return candidate
 			}
 		}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,4 +149,98 @@ func TestLoadAndSave(t *testing.T) {
 
 		assert.Error(t, err, "Should not mistake a broken catalog for an empty one")
 	})
+}
+
+func TestNewHandle(t *testing.T) {
+	var free []string
+
+	t.Run("ReadsLikeSomeoneAbbreviatingIt", func(t *testing.T) {
+		for name, want := range map[string]string{
+			"Enua 22/1 Wedding Cake":             "wcake",
+			"Pedanios 22/1 DNK Ghost Train Haze": "dgth",
+			"Cantourage 25/1 MAC1+":              "mac1",
+			"Khiron 20/1 Munson":                 "muns",
+		} {
+			t.Run(name, func(t *testing.T) {
+				got := NewHandle(Parse(name), free)
+				assert.Equal(t, want, got, "Should abbreviate the cultivar, not the manufacturer")
+			})
+		}
+	})
+
+	t.Run("AlwaysThreeToFiveCharacters", func(t *testing.T) {
+		for _, name := range []string{
+			"Enua 22/1 Wedding Cake", "X 1/1 Ab", "Maker 20/1 A", "Nothing At All",
+			"Cansativa Vanilla Cake 26/1", "CNBS FK 30/1: Florida Kush.",
+		} {
+			h := NewHandle(Parse(name), free)
+			assert.GreaterOrEqual(t, len(h), minHandle, "%q gave %q", name, h)
+			assert.LessOrEqual(t, len(h), maxHandle, "%q gave %q", name, h)
+			assert.NoError(t, CheckSlug(h), "%q gave %q, which is not a usable slug", name, h)
+		}
+	})
+
+	t.Run("AvoidsWhatIsAlreadyTaken", func(t *testing.T) {
+		c := &Catalog{}
+		var handles []string
+		// The same product bought five times over, which is what a recurring
+		// prescription looks like.
+		for i := 0; i < 5; i++ {
+			p := Parse("Enua 22/1 Wedding Cake")
+			p.Slug = NewHandle(p, c.Handles())
+			require.NoError(t, c.Add(p))
+			handles = append(handles, p.Slug)
+		}
+
+		seen := map[string]bool{}
+		for _, h := range handles {
+			assert.False(t, seen[h], "%q was handed out twice", h)
+			assert.LessOrEqual(t, len(h), maxHandle, "%q outgrew the limit", h)
+			seen[h] = true
+		}
+		// And none of them is a keystroke from another, since references are
+		// resolved by prefix.
+		for i, a := range handles {
+			for j, b := range handles {
+				if i != j {
+					assert.False(t, strings.HasPrefix(a, b),
+						"%q has %q as a prefix; one typo lands on the wrong jar", a, b)
+				}
+			}
+		}
+	})
+
+	t.Run("SurvivesAWholeCatalogOfCollisions", func(t *testing.T) {
+		c := &Catalog{}
+		for i := 0; i < 60; i++ {
+			p := Parse("Maker 20/1 Same Name")
+			p.Slug = NewHandle(p, c.Handles())
+			require.NoError(t, c.Add(p), "collision at %d", i)
+		}
+		assert.Len(t, c.Products, 60, "every one should have got its own slug")
+	})
+
+	t.Run("FallsBackToTheNameWithoutACultivar", func(t *testing.T) {
+		h := NewHandle(&Product{Name: "Liefermenge Indica"}, free)
+
+		assert.NotEmpty(t, h, "Should still produce something")
+		assert.GreaterOrEqual(t, len(h), minHandle)
+	})
+}
+
+func TestCheckSlug(t *testing.T) {
+	for _, ok := range []string{"wc", "wcake", "mac1", "ghost-train", "a1"} {
+		assert.NoError(t, CheckSlug(ok), "%q should be usable", ok)
+	}
+	for _, bad := range []string{"", "w", "Wcake", "wc ake", "wc/ake", "-wc", strings.Repeat("a", 25)} {
+		assert.ErrorIs(t, CheckSlug(bad), ErrBadSlug, "%q should be refused", bad)
+	}
+}
+
+func TestTaken(t *testing.T) {
+	c := &Catalog{}
+	require.NoError(t, c.Add(&Product{Slug: "wcake", Name: "Wedding Cake"}))
+
+	assert.True(t, c.Taken("wcake"), "Should know what it holds")
+	assert.False(t, c.Taken("lcook"), "and what it does not")
 }

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -34,11 +34,26 @@ func New(r *repo.Repo, products *catalog.Catalog, devices *catalog.Devices, stat
 
 // Buy records a prescription fill, adding the product to the catalog if it is
 // not known yet. The product is returned along with whether it was new.
-func (r *Recorder) Buy(name string, grams float64, at time.Time) (journal.Event, *catalog.Product, bool, error) {
+//
+// A slug may be given for a new product; left empty, a short one is made up
+// that is not already taken. It is the name every later entry refers to, so it
+// is settled once, when the product first appears, and never afterwards.
+func (r *Recorder) Buy(name, slug string, grams float64, at time.Time) (journal.Event, *catalog.Product, bool, error) {
 	product, err := r.products.Find(name)
 	added := false
 	if err != nil {
 		product = catalog.Parse(name)
+		if slug != "" {
+			if err := catalog.CheckSlug(slug); err != nil {
+				return journal.Event{}, nil, false, err
+			}
+			if r.products.Taken(slug) {
+				return journal.Event{}, nil, false, fmt.Errorf("the slug %q is already in use", slug)
+			}
+			product.Slug = slug
+		} else {
+			product.Slug = catalog.NewHandle(product, r.products.Handles())
+		}
 		if err := r.products.Add(product); err != nil {
 			return journal.Event{}, nil, false, err
 		}
@@ -338,3 +353,44 @@ func (r *Recorder) Difference(ref string, account journal.Account, weighed float
 
 // round trims to centigrams, the precision a jeweller's scale reads.
 func round(g float64) float64 { return math.Round(g*100) / 100 }
+
+// Rename changes what a product is called, and nothing else.
+//
+// The slug is left alone deliberately: it is the name every entry in the
+// journal refers to, and changing it would leave those entries pointing at a
+// product that no longer exists. What a jar is called can be corrected; what it
+// is remains what it was.
+func (r *Recorder) Rename(ref, name string) (*catalog.Product, error) {
+	product, err := r.products.Find(ref)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("a product needs a name")
+	}
+	product.Name = strings.TrimSpace(name)
+	if err := r.products.Save(r.repo.ProductsPath()); err != nil {
+		return nil, err
+	}
+	return product, nil
+}
+
+// Describe replaces a product's parsed details, leaving its slug and its
+// entries alone.
+func (r *Recorder) Describe(ref string, p catalog.Product) (*catalog.Product, error) {
+	product, err := r.products.Find(ref)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return nil, fmt.Errorf("a product needs a name")
+	}
+	product.Name = strings.TrimSpace(p.Name)
+	product.Manufacturer = strings.TrimSpace(p.Manufacturer)
+	product.Cultivar = strings.TrimSpace(p.Cultivar)
+	product.THC, product.CBD = p.THC, p.CBD
+	if err := r.products.Save(r.repo.ProductsPath()); err != nil {
+		return nil, err
+	}
+	return product, nil
+}

--- a/pkg/record/record_test.go
+++ b/pkg/record/record_test.go
@@ -34,38 +34,38 @@ func recorder(t *testing.T) *Recorder {
 func TestBuy(t *testing.T) {
 	rec := recorder(t)
 
-	e, p, added, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	e, p, added, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 
 	assert.True(t, added, "Should register a product it has not seen")
-	assert.Equal(t, "enua-wedding-cake", p.Slug, "Should slug the name")
+	assert.Equal(t, "wcake", p.Slug, "Should slug the name")
 	assert.Equal(t, journal.Purchase, e.Type, "Should record a purchase")
-	assert.Equal(t, 20.0, rec.Available("enua-wedding-cake", journal.Storage), "Should land in storage")
+	assert.Equal(t, 20.0, rec.Available("wcake", journal.Storage), "Should land in storage")
 
-	_, _, added, err = rec.Buy("Enua 22/1 Wedding Cake", 10, time.Now())
+	_, _, added, err = rec.Buy("Enua 22/1 Wedding Cake", "", 10, time.Now())
 	require.NoError(t, err)
 	assert.False(t, added, "Should reuse the product the second time")
-	assert.Equal(t, 30.0, rec.Available("enua-wedding-cake", journal.Storage), "Should top up storage")
+	assert.Equal(t, 30.0, rec.Available("wcake", journal.Storage), "Should top up storage")
 }
 
 func TestGrind(t *testing.T) {
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 
 	t.Run("MovesStorageIntoTheTin", func(t *testing.T) {
 		_, err := rec.Grind("wedding", 0.75, time.Now())
 		require.NoError(t, err)
 
-		assert.Equal(t, 19.25, rec.Available("enua-wedding-cake", journal.Storage), "Should leave storage short")
-		assert.Equal(t, 0.75, rec.Available("enua-wedding-cake", journal.Stash), "Should fill the tin")
+		assert.Equal(t, 19.25, rec.Available("wcake", journal.Storage), "Should leave storage short")
+		assert.Equal(t, 0.75, rec.Available("wcake", journal.Stash), "Should fill the tin")
 	})
 
 	t.Run("RefusesToOverdraw", func(t *testing.T) {
 		_, err := rec.Grind("wedding", 500, time.Now())
 
 		assert.ErrorContains(t, err, "cannot take", "Should refuse rather than go negative")
-		assert.Equal(t, 19.25, rec.Available("enua-wedding-cake", journal.Storage), "Should not have recorded anything")
+		assert.Equal(t, 19.25, rec.Available("wcake", journal.Storage), "Should not have recorded anything")
 	})
 
 	t.Run("UnknownProduct", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestGrind(t *testing.T) {
 
 func TestSession(t *testing.T) {
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 	_, err = rec.Grind("wedding", 1.0, time.Now())
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestSession(t *testing.T) {
 
 		assert.Equal(t, journal.Sesh, e.Type, "Should record a session")
 		assert.Equal(t, "evening", e.Note, "Should keep the note")
-		assert.Equal(t, 0.6, rec.Available("enua-wedding-cake", journal.Stash), "Should empty the tin by that much")
+		assert.Equal(t, 0.6, rec.Available("wcake", journal.Stash), "Should empty the tin by that much")
 	})
 
 	t.Run("RefusesMoreThanTheTinHolds", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestSession(t *testing.T) {
 
 func TestStateFollowsAlong(t *testing.T) {
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 
 	assert.Len(t, rec.State().Events, 1, "Should fold each entry as it is recorded")
@@ -127,7 +127,7 @@ func TestStateFollowsAlong(t *testing.T) {
 func TestRevert(t *testing.T) {
 	t.Run("PutsTheGramsBackWithoutRemovingAnything", func(t *testing.T) {
 		rec := recorder(t)
-		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 		require.NoError(t, err)
 		grind, err := rec.Grind("wedding", 2, time.Now())
 		require.NoError(t, err)
@@ -135,15 +135,15 @@ func TestRevert(t *testing.T) {
 		fix, err := rec.Revert(grind.Hash, "")
 		require.NoError(t, err)
 
-		assert.Equal(t, 20.0, rec.Available("enua-wedding-cake", journal.Storage), "Should restore storage")
-		assert.Zero(t, rec.Available("enua-wedding-cake", journal.Stash), "Should empty the tin again")
+		assert.Equal(t, 20.0, rec.Available("wcake", journal.Storage), "Should restore storage")
+		assert.Zero(t, rec.Available("wcake", journal.Stash), "Should empty the tin again")
 		assert.Equal(t, grind.Hash, fix.Reverts, "The correction should name what it undid")
 		assert.Len(t, rec.State().Events, 3, "Should keep the original and add the correction")
 	})
 
 	t.Run("RefusesToUndoTwice", func(t *testing.T) {
 		rec := recorder(t)
-		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 		require.NoError(t, err)
 		grind, err := rec.Grind("wedding", 2, time.Now())
 		require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestRevert(t *testing.T) {
 
 	t.Run("RefusesWhenTheGramsHaveMovedOn", func(t *testing.T) {
 		rec := recorder(t)
-		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 		require.NoError(t, err)
 		grind, err := rec.Grind("wedding", 2, time.Now())
 		require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestRevert(t *testing.T) {
 
 func TestAmend(t *testing.T) {
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 	grind, err := rec.Grind("wedding", 7.5, time.Now())
 	require.NoError(t, err)
@@ -187,14 +187,14 @@ func TestAmend(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0.75, corrected.Grams, "Should record the corrected amount")
-	assert.Equal(t, 0.75, rec.Available("enua-wedding-cake", journal.Stash), "The tin should hold the corrected amount")
-	assert.Equal(t, 19.25, rec.Available("enua-wedding-cake", journal.Storage), "Storage should reflect the correction")
+	assert.Equal(t, 0.75, rec.Available("wcake", journal.Stash), "The tin should hold the corrected amount")
+	assert.Equal(t, 19.25, rec.Available("wcake", journal.Storage), "Storage should reflect the correction")
 	assert.Len(t, rec.State().Events, 4, "Should keep the original, the undo and the replacement")
 }
 
 func TestReverted(t *testing.T) {
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 	grind, err := rec.Grind("wedding", 2, time.Now())
 	require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestReverted(t *testing.T) {
 func stocked(t *testing.T) *Recorder {
 	t.Helper()
 	rec := recorder(t)
-	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 	_, err = rec.Grind("wedding", 2, time.Now())
 	require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestReconcile(t *testing.T) {
 		assert.InDelta(t, 0.40, e.Grams, 0.001, "Should record the difference, not the weight")
 		assert.Equal(t, journal.Storage, e.From, "Should take the grams out of storage")
 		assert.Equal(t, journal.External, e.To, "and out of the system")
-		assert.InDelta(t, 17.60, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+		assert.InDelta(t, 17.60, rec.Available("wcake", journal.Storage), 0.001,
 			"Storage should now agree with the scale")
 	})
 
@@ -244,7 +244,7 @@ func TestReconcile(t *testing.T) {
 		assert.InDelta(t, 0.50, e.Grams, 0.001, "Should record the difference")
 		assert.Equal(t, journal.External, e.From, "Should bring the grams in from outside")
 		assert.Equal(t, journal.Storage, e.To, "and into storage")
-		assert.InDelta(t, 18.50, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+		assert.InDelta(t, 18.50, rec.Available("wcake", journal.Storage), 0.001,
 			"Storage should now agree with the scale")
 	})
 
@@ -254,9 +254,9 @@ func TestReconcile(t *testing.T) {
 		_, err := rec.Reconcile("wedding", journal.Stash, 1.75, "")
 		require.NoError(t, err)
 
-		assert.InDelta(t, 1.75, rec.Available("enua-wedding-cake", journal.Stash), 0.001,
+		assert.InDelta(t, 1.75, rec.Available("wcake", journal.Stash), 0.001,
 			"Should reconcile the tin as readily as storage")
-		assert.InDelta(t, 18.0, rec.Available("enua-wedding-cake", journal.Storage), 0.001,
+		assert.InDelta(t, 18.0, rec.Available("wcake", journal.Storage), 0.001,
 			"and should leave the other accounts alone")
 	})
 
@@ -276,7 +276,7 @@ func TestReconcile(t *testing.T) {
 		_, err := rec.Reconcile("wedding", journal.Storage, 0, "an empty jar")
 		require.NoError(t, err)
 
-		assert.Zero(t, rec.Available("enua-wedding-cake", journal.Storage),
+		assert.Zero(t, rec.Available("wcake", journal.Storage),
 			"An empty jar is a legitimate reading, and should empty the account")
 	})
 
@@ -320,7 +320,7 @@ func TestReconcile(t *testing.T) {
 
 		// An adjustment is a transfer, so the fold still accounts for every gram
 		// that came in, including the ones that left again.
-		b := rec.State().Balances["enua-wedding-cake"]
+		b := rec.State().Balances["wcake"]
 		assert.InDelta(t, 19.60, b.Storage+b.Stash+b.Consumed+b.AVB, 0.001,
 			"20 g bought, 0.40 g adjusted out")
 	})
@@ -335,4 +335,103 @@ func TestDifference(t *testing.T) {
 	assert.InDelta(t, 18.00, expected, 0.001, "Should report what the ledger believes")
 	assert.InDelta(t, -0.40, difference, 0.001, "and the signed difference")
 	assert.Len(t, rec.State().Events, 2, "without recording anything")
+}
+
+func TestBuyWithASlug(t *testing.T) {
+	t.Run("MakesOneUpWhenNoneIsGiven", func(t *testing.T) {
+		rec := recorder(t)
+
+		_, p, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
+		require.NoError(t, err)
+
+		assert.Equal(t, "wcake", p.Slug, "Should abbreviate the cultivar")
+		assert.NoError(t, catalog.CheckSlug(p.Slug), "and produce something usable")
+	})
+
+	t.Run("KeepsOneThatIsGiven", func(t *testing.T) {
+		rec := recorder(t)
+
+		_, p, _, err := rec.Buy("Enua 22/1 Wedding Cake", "cake", 20, time.Now())
+		require.NoError(t, err)
+
+		assert.Equal(t, "cake", p.Slug, "Should use what was asked for")
+		_, err = rec.Grind("cake", 1, time.Now())
+		assert.NoError(t, err, "and it should work as a reference")
+	})
+
+	t.Run("RefusesASlugAlreadyInUse", func(t *testing.T) {
+		rec := recorder(t)
+		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "cake", 20, time.Now())
+		require.NoError(t, err)
+
+		_, _, _, err = rec.Buy("Khiron 20/1 Munson", "cake", 10, time.Now())
+
+		assert.ErrorContains(t, err, "already in use",
+			"Two products sharing a slug would make every later entry ambiguous")
+	})
+
+	t.Run("RefusesAnUnusableSlug", func(t *testing.T) {
+		rec := recorder(t)
+
+		_, _, _, err := rec.Buy("Enua 22/1 Wedding Cake", "Wedding Cake", 20, time.Now())
+
+		assert.ErrorIs(t, err, catalog.ErrBadSlug, "Should refuse something that cannot be typed as one word")
+	})
+
+	t.Run("BuyingAgainKeepsTheFirstSlug", func(t *testing.T) {
+		rec := recorder(t)
+		_, first, _, err := rec.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
+		require.NoError(t, err)
+
+		_, again, added, err := rec.Buy("Enua 22/1 Wedding Cake", "", 10, time.Now())
+		require.NoError(t, err)
+
+		assert.False(t, added, "Should recognise the product")
+		assert.Equal(t, first.Slug, again.Slug, "and refer to it the same way as before")
+	})
+}
+
+func TestRenameAndDescribe(t *testing.T) {
+	t.Run("CorrectsTheName", func(t *testing.T) {
+		rec := stocked(t)
+
+		p, err := rec.Rename("wcake", "Enua 22/1 Wedding Cake (Batch 2)")
+		require.NoError(t, err)
+
+		assert.Equal(t, "Enua 22/1 Wedding Cake (Batch 2)", p.Name, "Should read as asked")
+		assert.Equal(t, "wcake", p.Slug, "and keep the slug the journal refers to")
+	})
+
+	t.Run("RefusesAnEmptyName", func(t *testing.T) {
+		rec := stocked(t)
+
+		_, err := rec.Rename("wcake", "   ")
+
+		assert.ErrorContains(t, err, "needs a name", "Should refuse to leave it nameless")
+	})
+
+	t.Run("DescribeReplacesTheParsedDetails", func(t *testing.T) {
+		rec := stocked(t)
+
+		p, err := rec.Describe("wcake", catalog.Product{
+			Name: "Wedding Cake", Manufacturer: "Enua", Cultivar: "Wedding Cake", THC: 21.5, CBD: 0.8,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "Enua", p.Manufacturer, "Should correct the manufacturer")
+		assert.InDelta(t, 21.5, p.THC, 0.001, "and the potency the parser guessed at")
+		assert.Equal(t, "wcake", p.Slug, "without touching the slug")
+	})
+
+	t.Run("EntriesStillResolveAfterwards", func(t *testing.T) {
+		rec := stocked(t)
+		_, err := rec.Rename("wcake", "Something Else Entirely")
+		require.NoError(t, err)
+
+		// The journal refers to the slug, so a rename cannot orphan anything.
+		_, err = rec.Grind("wcake", 1, time.Now())
+		assert.NoError(t, err, "Should still take entries against the renamed product")
+		assert.InDelta(t, 17.0, rec.Available("wcake", journal.Storage), 0.001,
+			"and its balances should be unchanged")
+	})
 }

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -166,6 +166,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.notice, a.failed = msg.err.Error(), true
 			return a, nil
 		}
+		if msg.event.Type == "" {
+			// A product was edited rather than an entry recorded.
+			a.notice, a.failed = fmt.Sprintf("renamed %s to %s", msg.event.Product, msg.event.Note), false
+			return a, a.reload()
+		}
 		a.notice, a.failed = fmt.Sprintf("recorded %s %.2fg %s",
 			msg.event.Type, msg.event.Grams, msg.event.Product), false
 		return a, a.reload()
@@ -225,6 +230,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case msg.String() == "a" && a.screen == devicesScreen:
 			a.device, a.notice = newDeviceForm(nil, a), ""
 			return a, a.device.form.Init()
+		case msg.String() == "e" && a.screen == productsScreen:
+			if r := a.products.Selected(a); r != nil {
+				a.entry, a.notice = newDescribeForm(r.Slug, a), ""
+				return a, a.entry.form.Init()
+			}
+			return a, nil
 		case msg.String() == "r" && a.screen != journalScreen:
 			if slug := a.weighable(); slug != "" {
 				a.entry, a.notice = newReconcileForm(slug, a), ""

--- a/pkg/tui/entry.go
+++ b/pkg/tui/entry.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/TheDonDope/wits/pkg/catalog"
 	"github.com/TheDonDope/wits/pkg/journal"
 	"github.com/TheDonDope/wits/pkg/ledger"
 	"github.com/TheDonDope/wits/pkg/record"
@@ -37,6 +38,8 @@ func (k entryKind) String() string {
 		return "Undo entry"
 	case entryReconcile:
 		return "Weigh and reconcile"
+	case entryDescribe:
+		return "Edit product"
 	default:
 		return "Grind"
 	}
@@ -213,7 +216,7 @@ func (f *entryForm) commit(a *App) (journal.Event, error) {
 	at := time.Now()
 
 	var grams float64
-	if f.kind != entryUndo && f.kind != entryReconcile {
+	if f.kind != entryUndo && f.kind != entryReconcile && f.kind != entryDescribe {
 		var err error
 		if grams, err = parseGrams(f.amount); err != nil {
 			return journal.Event{}, err
@@ -221,6 +224,18 @@ func (f *entryForm) commit(a *App) (journal.Event, error) {
 	}
 
 	switch f.kind {
+	case entryDescribe:
+		p, err := rec.Describe(f.product, catalog.Product{
+			Name:         f.name,
+			Manufacturer: f.device,
+			Cultivar:     f.note,
+			THC:          parseFloatOrZero(f.amount),
+			CBD:          parseFloatOrZero(f.temp),
+		})
+		if err != nil {
+			return journal.Event{}, err
+		}
+		return journal.Event{Product: p.Slug, Note: p.Name}, nil
 	case entryReconcile:
 		weighed, err := strconv.ParseFloat(
 			strings.Replace(strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(f.amount), "g")), ",", ".", 1), 64)
@@ -236,7 +251,7 @@ func (f *entryForm) commit(a *App) (journal.Event, error) {
 	case entryAmend:
 		return rec.Amend(f.target.Hash, grams, strings.TrimSpace(f.note))
 	case entryBuy:
-		e, _, _, err := rec.Buy(strings.TrimSpace(f.name), grams, at)
+		e, _, _, err := rec.Buy(strings.TrimSpace(f.name), strings.TrimSpace(f.device), grams, at)
 		return e, err
 	case entryGrind:
 		return rec.Grind(f.product, grams, at)
@@ -363,4 +378,67 @@ func nonNegativeGrams(s string) error {
 		return fmt.Errorf("a weight cannot be negative")
 	}
 	return nil
+}
+
+// entryDescribe corrects what a product is called and what is known about it.
+const entryDescribe entryKind = iota + 300
+
+// newDescribeForm edits a product's details.
+//
+// The slug is shown but not offered for editing. It is the name every entry in
+// the journal refers to, and changing it would leave those entries pointing at
+// a product that no longer exists. What a jar is called can be corrected; which
+// jar it is cannot.
+func newDescribeForm(slug string, a *App) *entryForm {
+	f := &entryForm{kind: entryDescribe, product: slug}
+
+	p, err := a.data.Products.Find(slug)
+	if err != nil {
+		p = &catalog.Product{Slug: slug, Name: slug}
+	}
+	f.name = p.Name
+	f.device = p.Manufacturer // reused for the manufacturer
+	f.note = p.Cultivar       // and for the cultivar
+	f.amount = trimZero(p.THC)
+	f.temp = trimZero(p.CBD)
+
+	f.form = huh.NewForm(huh.NewGroup(
+		huh.NewNote().Title(slug).
+			Description("The slug stays as it is: every entry in the journal refers\nto it, and renaming it would orphan them."),
+		huh.NewInput().Title("Name").Description("As it should read").
+			Value(&f.name).Validate(required("a name")),
+		huh.NewInput().Title("Manufacturer").Value(&f.device),
+		huh.NewInput().Title("Cultivar").Value(&f.note),
+		huh.NewInput().Title("THC %").Value(&f.amount).Validate(optionalFloat),
+		huh.NewInput().Title("CBD %").Value(&f.temp).Validate(optionalFloat),
+	)).WithShowHelp(true).WithWidth(minInt(a.inner(), 72))
+	return f
+}
+
+// trimZero renders a percentage, or nothing when it is unset.
+func trimZero(f float64) string {
+	if f == 0 {
+		return ""
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// optionalFloat accepts a percentage or nothing at all.
+func optionalFloat(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	if _, err := strconv.ParseFloat(strings.Replace(strings.TrimSpace(s), ",", ".", 1), 64); err != nil {
+		return fmt.Errorf("not a percentage")
+	}
+	return nil
+}
+
+// parseFloatOrZero reads a percentage, treating anything unreadable as unset.
+func parseFloatOrZero(s string) float64 {
+	v, err := strconv.ParseFloat(strings.Replace(strings.TrimSpace(s), ",", ".", 1), 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }

--- a/pkg/tui/entry_test.go
+++ b/pkg/tui/entry_test.go
@@ -24,11 +24,11 @@ func liveApp(t *testing.T) *App {
 	require.NoError(t, err)
 
 	products := &catalog.Catalog{}
-	require.NoError(t, products.Add(catalog.Parse("Enua 22/1 Wedding Cake")))
+	require.NoError(t, products.Add(product("Enua 22/1 Wedding Cake", "wcake")))
 	require.NoError(t, products.Save(r.ProductsPath()))
 
 	_, err = r.Journal().Append(journal.Event{
-		Type: journal.Purchase, Product: "enua-wedding-cake", Grams: 20,
+		Type: journal.Purchase, Product: "wcake", Grams: 20,
 		From: journal.External, To: journal.Storage, OccurredAt: time.Now(),
 	})
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestNoticeAfterAnEntry(t *testing.T) {
 	app := liveApp(t)
 	var m tea.Model = app
 
-	m.Update(entryDoneMsg{event: journal.Event{Type: journal.Grind, Grams: 0.75, Product: "enua-wedding-cake"}})
+	m.Update(entryDoneMsg{event: journal.Event{Type: journal.Grind, Grams: 0.75, Product: "wcake"}})
 
 	assert.Contains(t, app.notice, "0.75", "Should confirm what was recorded")
 	assert.False(t, app.failed, "Should not read as a failure")
@@ -256,7 +256,7 @@ func TestUndoFromTheJournal(t *testing.T) {
 	m, _ = send(m, tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = typeText(m, "2")
 	m, _ = send(m, tea.KeyPressMsg{Code: tea.KeyEnter})
-	require.Equal(t, 2.0, app.data.State.Balances["enua-wedding-cake"].Stash)
+	require.Equal(t, 2.0, app.data.State.Balances["wcake"].Stash)
 
 	// Move to the journal, put the cursor on the grind, and undo it.
 	m, _ = send(m, tea.KeyPressMsg{Code: 'l', Text: "l"})
@@ -278,7 +278,7 @@ func TestUndoFromTheJournal(t *testing.T) {
 	require.True(t, ok, "Should report the outcome, got %v", msgs)
 	require.NoError(t, done.err)
 
-	assert.Zero(t, app.data.State.Balances["enua-wedding-cake"].Stash, "The grams should be back in storage")
+	assert.Zero(t, app.data.State.Balances["wcake"].Stash, "The grams should be back in storage")
 	events, err := app.data.Repo.Journal().Events()
 	require.NoError(t, err)
 	assert.Len(t, events, 3, "Nothing should have been removed: the correction is appended")

--- a/pkg/tui/products.go
+++ b/pkg/tui/products.go
@@ -26,21 +26,22 @@ func newProductsView() productsView { return productsView{} }
 
 type productKeys struct {
 	keyMap
-	Reconcile, All key.Binding
+	Reconcile, Edit, All key.Binding
 }
 
 func (k productKeys) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Reconcile, k.All, k.Help, k.Quit}
+	return []key.Binding{k.Up, k.Down, k.Reconcile, k.Edit, k.All, k.Help, k.Quit}
 }
 
 func (k productKeys) FullHelp() [][]key.Binding {
-	return append(k.keyMap.FullHelp(), []key.Binding{k.Reconcile, k.All})
+	return append(k.keyMap.FullHelp(), []key.Binding{k.Reconcile, k.Edit, k.All})
 }
 
 func (v productsView) keys(base keyMap) help.KeyMap {
 	return productKeys{
 		keyMap:    base,
 		Reconcile: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "weigh")),
+		Edit:      key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
 		All:       key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all/held")),
 	}
 }
@@ -253,7 +254,8 @@ func (v productsView) detail(a *App, r productRow, width int) string {
 			"  ", bar, " ",
 			t.Dim.Render(fmt.Sprintf("%.2f g of %.2f g dispensed still held", r.Held(), r.Bought)),
 		),
-		"  "+t.Dim.Render("press ")+t.Key.Render("r")+t.Dim.Render(" to weigh it and make the ledger agree"),
+		"  "+t.Dim.Render("press ")+t.Key.Render("r")+t.Dim.Render(" to weigh it, ")+
+			t.Key.Render("e")+t.Dim.Render(" to correct its name"),
 		"",
 	)
 }

--- a/pkg/tui/products_test.go
+++ b/pkg/tui/products_test.go
@@ -20,7 +20,7 @@ func shelved(t *testing.T) *App {
 	app := liveApp(t)
 	rec := record.New(app.data.Repo, app.data.Products, app.data.Devices, app.data.State)
 
-	_, _, _, err := rec.Buy("Cannamedical 28/1 Lemon Cookie", 10, time.Now().AddDate(0, 0, -2))
+	_, _, _, err := rec.Buy("Cannamedical 28/1 Lemon Cookie", "", 10, time.Now().AddDate(0, 0, -2))
 	require.NoError(t, err)
 	_, err = rec.Grind("lemon", 10, time.Now().AddDate(0, 0, -1))
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestWeighPicksTheFullestJarOffTheProductsScreen(t *testing.T) {
 	// with the most left — the one most worth checking.
 	slug := app.weighable()
 
-	assert.Equal(t, "enua-wedding-cake", slug, "Should pick the fullest jar of the cycle")
+	assert.Equal(t, "wcake", slug, "Should pick the fullest jar of the cycle")
 }
 
 func TestReconcileFromTheInterface(t *testing.T) {
@@ -129,7 +129,7 @@ func TestReconcileFromTheInterface(t *testing.T) {
 	app.screen = productsScreen
 	var m tea.Model = app
 
-	before := app.data.State.Balances["enua-wedding-cake"].Storage
+	before := app.data.State.Balances["wcake"].Storage
 	require.InDelta(t, 18.0, before, 0.001)
 
 	m, _ = send(m, tea.KeyPressMsg{Code: 'r', Text: "r"})
@@ -146,7 +146,7 @@ func TestReconcileFromTheInterface(t *testing.T) {
 
 	assert.Equal(t, journal.Adjust, done.event.Type, "Should record an adjustment")
 	assert.InDelta(t, 0.40, done.event.Grams, 0.001, "of the difference, not the weight")
-	assert.InDelta(t, 17.6, app.data.State.Balances["enua-wedding-cake"].Storage, 0.001,
+	assert.InDelta(t, 17.6, app.data.State.Balances["wcake"].Storage, 0.001,
 		"and storage should now agree with the scale")
 }
 
@@ -175,4 +175,45 @@ func TestQuickActionsFoldAwayWhenNarrow(t *testing.T) {
 		assert.LessOrEqual(t, lipgloss.Width(line), 41,
 			"the boxes should not push the frame sideways: %q", line)
 	}
+}
+
+func TestEditProductFromTheScreen(t *testing.T) {
+	app := shelved(t)
+	app.screen = productsScreen
+	var m tea.Model = app
+
+	m, _ = send(m, tea.KeyPressMsg{Code: 'e', Text: "e"})
+	require.NotNil(t, app.entry, "e should open the edit form")
+	assert.Contains(t, stripANSI(app.entry.View(app, 92)), "Edit product", "Should say what it is")
+	assert.Contains(t, stripANSI(app.entry.View(app, 92)), "slug stays as it is",
+		"and why the slug is not on offer")
+
+	// The name is prefilled; appending to it is enough to change it.
+	m = typeText(m, " II")
+	_, msgs := confirmThrough(m, 10)
+
+	done, ok := findDone(msgs)
+	require.True(t, ok, "Should report the outcome, got %v", msgs)
+	require.NoError(t, done.err)
+
+	p, err := app.data.Products.Find("wcake")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(p.Name, " II"), "Should have written the corrected name, got %q", p.Name)
+	assert.Equal(t, "wcake", p.Slug, "and left the slug the journal refers to alone")
+}
+
+func TestEditingAProductDoesNotOrphanItsEntries(t *testing.T) {
+	app := shelved(t)
+	before := len(app.data.State.Events)
+
+	rec := record.New(app.data.Repo, app.data.Products, app.data.Devices, app.data.State)
+	_, err := rec.Rename("wcake", "Renamed Entirely")
+	require.NoError(t, err)
+
+	reloaded, err := Load(app.data.Repo)
+	require.NoError(t, err)
+
+	assert.Len(t, reloaded.State.Events, before, "Renaming records nothing and loses nothing")
+	assert.Equal(t, "Renamed Entirely", reloaded.ProductName("wcake"),
+		"and the entries still resolve to the product, under its new name")
 }

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -38,16 +38,18 @@ func sample(t *testing.T) Data {
 		}
 	}
 	events := []journal.Event{
-		mk(journal.Purchase, "enua-wedding-cake", 20, 0),
-		mk(journal.Purchase, "cannamedical-lemon-cookie", 10, 0),
-		mk(journal.Grind, "enua-wedding-cake", 0.75, 1),
-		mk(journal.Grind, "cannamedical-lemon-cookie", 1.25, 1),
-		mk(journal.Sesh, "enua-wedding-cake", 0.30, 2),
-		mk(journal.Grind, "enua-wedding-cake", 1.10, 3),
+		mk(journal.Purchase, "wcake", 20, 0),
+		mk(journal.Purchase, "lcook", 10, 0),
+		mk(journal.Grind, "wcake", 0.75, 1),
+		mk(journal.Grind, "lcook", 1.25, 1),
+		mk(journal.Sesh, "wcake", 0.30, 2),
+		mk(journal.Grind, "wcake", 1.10, 3),
 	}
+	// Slugs are set to match the entries above: a catalog whose slugs disagree
+	// with the journal is not a fixture, it is a bug being tested.
 	products := &catalog.Catalog{}
-	require.NoError(t, products.Add(catalog.Parse("Enua 22/1 Wedding Cake")))
-	require.NoError(t, products.Add(catalog.Parse("Cannamedical 28/1 Lemon Cookie")))
+	require.NoError(t, products.Add(product("Enua 22/1 Wedding Cake", "wcake")))
+	require.NoError(t, products.Add(product("Cannamedical 28/1 Lemon Cookie", "lcook")))
 
 	return Data{
 		Workspace: &workspace.Workspace{
@@ -180,6 +182,13 @@ func TestEventLineHidesAMeaninglessTime(t *testing.T) {
 		"A backfilled entry has no time of day, and should not claim one")
 	assert.Contains(t, stripANSI(th.EventLine(evening, "X", 80, false)), "21:30",
 		"A real time should be shown")
+}
+
+// product parses a display name and pins its slug.
+func product(name, slug string) *catalog.Product {
+	p := catalog.Parse(name)
+	p.Slug = slug
+	return p
 }
 
 // emptyData is a repository with nothing in it.

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -30,7 +30,7 @@ func filled(t *testing.T) *repo.Repo {
 
 	ws, err := Read(r)
 	require.NoError(t, err)
-	_, _, _, err = ws.Recorder.Buy("Enua 22/1 Wedding Cake", 20, time.Now())
+	_, _, _, err = ws.Recorder.Buy("Enua 22/1 Wedding Cake", "", 20, time.Now())
 	require.NoError(t, err)
 	_, err = ws.Recorder.Grind("wedding", 0.75, time.Now())
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestRead(t *testing.T) {
 	assert.Len(t, ws.Events(), 2, "Should have read the journal")
 	assert.Len(t, ws.Products.Products, 1, "Should have read the catalog")
 	assert.NotNil(t, ws.Devices, "Should have read the devices, even when there are none")
-	assert.Equal(t, 19.25, ws.State.Balances["enua-wedding-cake"].Storage, "Should have folded the journal")
+	assert.Equal(t, 19.25, ws.State.Balances["wcake"].Storage, "Should have folded the journal")
 	assert.NotNil(t, ws.Recorder, "Should be ready to record")
 	assert.False(t, ws.OpenedAt.IsZero(), "Should stamp when the snapshot was taken")
 }
@@ -74,7 +74,7 @@ func TestSnapshotDoesNotMoveUnderneath(t *testing.T) {
 
 	// Something else writes to the same repository.
 	_, err = r.Journal().Append(journal.Event{
-		Type: journal.Grind, Product: "enua-wedding-cake", Grams: 0.5,
+		Type: journal.Grind, Product: "wcake", Grams: 0.5,
 		From: journal.Storage, To: journal.Stash, OccurredAt: time.Now(),
 	})
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestProductName(t *testing.T) {
 	ws, err := Read(filled(t))
 	require.NoError(t, err)
 
-	assert.Equal(t, "Enua 22/1 Wedding Cake", ws.ProductName("enua-wedding-cake"),
+	assert.Equal(t, "Enua 22/1 Wedding Cake", ws.ProductName("wcake"),
 		"Should resolve a slug to its display name")
 	assert.Equal(t, "not-in-the-catalog", ws.ProductName("not-in-the-catalog"),
 		"and should fall back to the slug, so an orphaned entry still reads sensibly")


### PR DESCRIPTION
## Description

Short product handles, editing a product's details, and tab completion for the commands that take one.

### Handles

`enua-wedding-cake` is precise and nobody wants to type it every evening. Every product now gets a three-to-five character handle when it is first bought, taken from the **cultivar** — that is what distinguishes one jar from the next, not the manufacturer:

```console
$ wits buy "Enua 22/1 Wedding Cake" 20g
New product Enua 22/1 Wedding Cake — refer to it as wcake
[029efe8] purchase 20.00g wcake into storage
```

`--slug lemon` chooses one by hand. It is said plainly at creation because it is what every later command refers to.

**A generated handle is never one keystroke from an existing one.** References resolve by prefix, so `wcake` and `wcak` both existing would mean a typo lands grams on the wrong jar — and these are medical records. A candidate that is a prefix of a taken slug, or has one as its prefix, is rejected. Four products with the same cultivar come out as:

```
Enua 22/1 Wedding Cake    → wcake
Enua 25/1 Wedding Cake    → wedd
Khiron 20/1 Wedding Cake  → wed2
Tilray 18/1 Wedding Cake  → we2
```

I found this by running it, not by reasoning about it: the first version handed out `wcake` and `wcak` side by side.

### Editing a product

`e` on the products screen corrects the name, manufacturer, cultivar and the potency the parser guessed at.

**The slug is shown but not editable.** It is the name every journal entry refers to, and renaming it would leave those entries pointing at a product that no longer exists — an orphaning the append-only log cannot repair. What a jar is *called* can be corrected; which jar it *is* cannot. There is a test asserting a rename loses no entries and leaves the balances intact.

### Completion

```console
$ wits grind <TAB>
lcook   10.00 g · Cannamedical 28/1 Lemon Cookie
mac1    15.00 g · Cantourage 25/1 MAC1+
wcake   18.00 g · Enua 22/1 Wedding Cake
```

Account-aware: `grind` offers what has storage, `sesh` offers only what is in a tin, so it cannot suggest something the command would refuse. Each candidate carries the display name and the amount left, since a handle on its own is not recognisable. `revert` completes on entry hashes with a description of each.

The `completion` command is no longer hidden — tab completion is most of what makes short handles worth having.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] `go test ./... -race`, `go vet`, `gofmt` clean; builds for Linux and Windows
- [x] Handle generation covered for shape, the 3–5 bound, a catalog of 60 collisions, and that no handle is a prefix of another
- [x] `--slug` covered: kept when given, refused when taken or unusable, and a repeat purchase keeping the first handle
- [x] Rename and describe covered, including that entries still resolve afterwards
- [x] Completion covered for both accounts, prefix filtering, and offering nothing for the amount argument

## Notes for the reviewer

**The importer still derives long deterministic slugs.** It reads four years in one pass, where a handle nobody will type by hand is a fair trade for one that cannot collide — and changing it would rewrite the slugs in an existing repository and in the integration test that reconciles against the real workbook. Worth revisiting if you would rather have short handles throughout; it is a one-line change plus a re-import.

Test fixtures that previously asserted the long slugs now assert the generated ones. Two of them had to be made self-consistent: they built catalog products through `Slugify` while their journal entries used the new handles, so the catalog and the journal disagreed — which is a bug being tested rather than a fixture.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
