### PR TITLE
witsnap: the camera and the tap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT_SHA = $(shell git rev-parse --short HEAD)
 COMMIT_DATE = $(shell git --no-pager log -1 --pretty='format:%cd' --date='format:%Y-%m-%dT%H:%M:%S')
 
 .PHONY: run install build build-windows clean doc changelog render-tapes \
-	test test-ci cover show-cover vet preflight release
+	test test-ci cover show-cover vet preflight snap release
 
 .DEFAULT_GOAL := build
 
@@ -77,6 +77,10 @@ vet:
 # Everything the CI and the Codacy gate will say, said here first.
 preflight:
 	./preflight.sh
+
+# The camera and the tap: screens as text, the fold as JSON.
+snap:
+	go build -o ./bin/witsnap ./cmd/witsnap
 
 # The guard checks where VERSION came from, not whether it is empty: it always
 # has a value here, because it defaults to the previous tag — and releasing

--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ make preflight  # everything CI and the Codacy gate will say, said here first
 `./preflight.sh watch <pr>` polls a pull request's checks and reads the Codacy
 delta the way the gate does, so a red X never comes as a surprise.
 
+`make snap` builds `witsnap`, the camera and the tap: `witsnap screens` renders
+any screen as plain text — `--press p,tick,tick` photographs a replay mid-run —
+and `witsnap json` writes the whole derived state as JSON, which is the seam a
+new client or a new visualisation starts from.
+
 `make build-windows` cross-compiles `bin/wits.exe`. `make render-tapes` re-records
 every GIF in `assets/` from the `*.tape` files; it needs `vhs`, `gum` and `ttyd`
 (`make install` covers the first two). The tapes seed a throwaway repository

--- a/cmd/witsnap/main.go
+++ b/cmd/witsnap/main.go
@@ -1,0 +1,238 @@
+// Command witsnap photographs a wits repository: every screen of the
+// interface as plain text, or the whole derived state as JSON.
+//
+// It exists for the work around the work. Pull requests want captures of the
+// screens they change; new clients and new visualisations want the fold's
+// numbers without scraping a terminal. Both come from the same seams the
+// application itself uses, so what witsnap says is what wits would say.
+//
+//	witsnap screens --repo /tmp/wits-demo
+//	witsnap screens --screen storage --press p,tick,tick
+//	witsnap json --repo /tmp/wits-demo | jq .balances
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/TheDonDope/wits/pkg/journal"
+	"github.com/TheDonDope/wits/pkg/ledger"
+	"github.com/TheDonDope/wits/pkg/tui"
+	"github.com/TheDonDope/wits/pkg/workspace"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fail("usage: witsnap <screens|json> [flags]")
+	}
+	var err error
+	switch os.Args[1] {
+	case "screens":
+		err = screens(os.Args[2:])
+	case "json":
+		err = dump(os.Args[2:])
+	default:
+		err = fmt.Errorf("unknown command %q; witsnap knows screens and json", os.Args[1])
+	}
+	if err != nil {
+		fail(err.Error())
+	}
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+// open reads the repository the flags point at, or the working directory.
+func open(dir string) (*workspace.Workspace, error) {
+	if dir == "" {
+		return workspace.Here()
+	}
+	return workspace.Open(dir)
+}
+
+// screens renders one screen or all of them, in the order of the tab bar.
+func screens(args []string) error {
+	fs := flag.NewFlagSet("screens", flag.ExitOnError)
+	repo := fs.String("repo", "", "the repository to photograph; defaults to the working directory")
+	name := fs.String("screen", "", "one screen rather than all of them")
+	width := fs.Int("width", 100, "the terminal width to render at")
+	height := fs.Int("height", 40, "the terminal height to render at")
+	press := fs.String("press", "", "keys to press first, comma separated — p,tick,tick replays")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ws, err := open(*repo)
+	if err != nil {
+		return err
+	}
+	var presses []string
+	if *press != "" {
+		presses = strings.Split(*press, ",")
+	}
+	names := tui.ScreenNames()
+	if *name != "" {
+		names = []string{*name}
+	}
+	for _, n := range names {
+		shot, err := tui.Snapshot(tui.From(ws), n, *width, *height, presses)
+		if err != nil {
+			return err
+		}
+		if len(names) > 1 {
+			fmt.Printf("==== %s ====\n", n)
+		}
+		fmt.Println(strings.TrimRight(shot, "\n"))
+	}
+	return nil
+}
+
+// state is the JSON shape of everything the fold derives: the contract a new
+// client can start from without reading a single screen.
+type state struct {
+	GeneratedAt time.Time                  `json:"generated_at"`
+	Events      int                        `json:"events"`
+	Balances    map[string]*ledger.Balance `json:"balances"`
+	Cycles      []ledger.Cycle             `json:"cycles"`
+	Current     *currentCycle              `json:"current_cycle,omitempty"`
+	PerDay      map[string]dayTotals       `json:"per_day"`
+	Devices     []deviceUse                `json:"device_usage"`
+}
+
+type currentCycle struct {
+	Start        time.Time `json:"start"`
+	Held         float64   `json:"held"`
+	Remaining    float64   `json:"remaining"`
+	RemainingPct float64   `json:"remaining_pct"`
+	PerActiveDay float64   `json:"per_active_day"`
+	DaysLeft     float64   `json:"days_left"`
+}
+
+type dayTotals struct {
+	Ground float64 `json:"ground,omitempty"`
+	Seshed float64 `json:"seshed,omitempty"`
+}
+
+type deviceUse struct {
+	Device   string  `json:"device"`
+	Sessions int     `json:"sessions"`
+	Grams    float64 `json:"grams"`
+	AvgTemp  int     `json:"avg_temp,omitempty"`
+}
+
+// dump writes the derived state as JSON.
+func dump(args []string) error {
+	fs := flag.NewFlagSet("json", flag.ExitOnError)
+	repo := fs.String("repo", "", "the repository to read; defaults to the working directory")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	ws, err := open(*repo)
+	if err != nil {
+		return err
+	}
+
+	out := state{
+		GeneratedAt: time.Now().Truncate(time.Second),
+		Events:      len(ws.State.Events),
+		Balances:    ws.State.Balances,
+		Cycles:      cyclesOf(ws),
+		Current:     current(ws),
+		PerDay:      perDay(ws),
+		Devices:     deviceUsage(ws),
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// cyclesOf strips the event lists out of the cycles: a client that wants the
+// events can read the journal, and the summary should stay a summary.
+func cyclesOf(ws *workspace.Workspace) []ledger.Cycle {
+	out := make([]ledger.Cycle, len(ws.State.Cycles))
+	for i, c := range ws.State.Cycles {
+		c.Events = nil
+		out[i] = c
+	}
+	return out
+}
+
+// current summarises the cycle in progress, if there is one.
+func current(ws *workspace.Workspace) *currentCycle {
+	c := ws.Cycle()
+	if c == nil {
+		return nil
+	}
+	stats := ledger.Summarise(c.Events)
+	return &currentCycle{
+		Start:        c.Start,
+		Held:         c.Held(),
+		Remaining:    c.Remaining(),
+		RemainingPct: c.RemainingPct(),
+		PerActiveDay: stats.PerActiveDay,
+		DaysLeft:     stats.DaysLeft(c.Remaining()),
+	}
+}
+
+// perDay totals the grams ground and seshed per calendar day.
+func perDay(ws *workspace.Workspace) map[string]dayTotals {
+	out := map[string]dayTotals{}
+	for _, e := range ws.State.Events {
+		day := e.OccurredAt.Format(time.DateOnly)
+		t := out[day]
+		switch e.Type {
+		case journal.Grind:
+			t.Ground = ledger.Round(t.Ground + e.Grams)
+		case journal.Sesh:
+			t.Seshed = ledger.Round(t.Seshed + e.Grams)
+		default:
+			continue
+		}
+		out[day] = t
+	}
+	return out
+}
+
+// deviceUsage totals the sessions per device, the way the sessions screen
+// counts them: sessions without a device are owned rather than dropped.
+func deviceUsage(ws *workspace.Workspace) []deviceUse {
+	byDev := map[string]*deviceUse{}
+	var order []string
+	temps := map[string][2]int{}
+	for _, e := range ws.State.Events {
+		if e.Type != journal.Sesh {
+			continue
+		}
+		name := e.Device
+		if name == "" {
+			name = "no device"
+		}
+		u, ok := byDev[name]
+		if !ok {
+			u = &deviceUse{Device: name}
+			byDev[name] = u
+			order = append(order, name)
+		}
+		u.Sessions++
+		u.Grams = ledger.Round(u.Grams + e.Grams)
+		if e.Temperature > 0 {
+			t := temps[name]
+			temps[name] = [2]int{t[0] + e.Temperature, t[1] + 1}
+		}
+	}
+	out := make([]deviceUse, 0, len(order))
+	for _, name := range order {
+		u := byDev[name]
+		if t := temps[name]; t[1] > 0 {
+			u.AvgTemp = t[0] / t[1]
+		}
+		out = append(out, *u)
+	}
+	return out
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -626,3 +626,88 @@ func (a *App) weighable() string {
 
 // inner returns the width available inside the frame.
 func (a *App) inner() int { return max(a.width-2, 10) }
+
+// ScreenNames lists the screens a Snapshot can render, in tab order.
+func ScreenNames() []string {
+	out := make([]string, len(tabs))
+	for i, name := range tabs {
+		out[i] = strings.ToLower(name)
+	}
+	return out
+}
+
+// Snapshot renders one screen to plain text, no terminal required. It is the
+// seam the tooling photographs through — pull request captures, quick visual
+// checks, future clients that want to see what the interface would say —
+// driving the same model the running program drives, keystroke by keystroke.
+func Snapshot(data Data, screenName string, width, height int, presses []string) (string, error) {
+	at := -1
+	for i, name := range tabs {
+		if strings.EqualFold(name, screenName) {
+			at = i
+		}
+	}
+	if at < 0 {
+		return "", fmt.Errorf("no screen called %q; the screens are %s",
+			screenName, strings.Join(ScreenNames(), ", "))
+	}
+
+	app := New(data)
+	app.screen = screen(at)
+	var m tea.Model = app
+	m, _ = m.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	for _, press := range presses {
+		msg, err := pressFor(press)
+		if err != nil {
+			return "", err
+		}
+		m, _ = m.Update(msg)
+	}
+	return stripANSI(m.View().Content), nil
+}
+
+// pressFor turns a spelled-out key into the message the runtime would send.
+// "tick" is the playback clock, so a replay can be photographed mid-run.
+func pressFor(press string) (tea.Msg, error) {
+	switch press {
+	case "tick":
+		return playTickMsg{}, nil
+	case "tab":
+		return tea.KeyPressMsg{Code: tea.KeyTab}, nil
+	case "shift+tab":
+		return tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}, nil
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}, nil
+	case "space":
+		return tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}, nil
+	case "left":
+		return tea.KeyPressMsg{Code: tea.KeyLeft}, nil
+	case "right":
+		return tea.KeyPressMsg{Code: tea.KeyRight}, nil
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}, nil
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}, nil
+	}
+	runes := []rune(press)
+	if len(runes) != 1 {
+		return nil, fmt.Errorf("cannot press %q; use a single key, tick, or a named key", press)
+	}
+	return tea.KeyPressMsg{Code: runes[0], Text: press}, nil
+}
+
+// stripANSI removes the escape sequences from a rendered frame, leaving the
+// text a capture or an assertion can read.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -71,21 +71,6 @@ func render(t *testing.T, data Data, s screen, w, h int) string {
 	return stripANSI(m.View().Content)
 }
 
-// stripANSI removes escape sequences so assertions can be made on the text.
-func stripANSI(s string) string {
-	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		if s[i] == 0x1b {
-			for i < len(s) && s[i] != 'm' {
-				i++
-			}
-			continue
-		}
-		b.WriteByte(s[i])
-	}
-	return b.String()
-}
-
 func TestDashboard(t *testing.T) {
 	out := render(t, sample(t), dashboardScreen, 96, 44)
 
@@ -314,4 +299,21 @@ func TestAnalysisByProductKeepsFullNames(t *testing.T) {
 		"By product must never shorten a name")
 	assert.Contains(t, out, "g/day", "and should rate each product")
 	assert.Contains(t, out, "%", "and give its share")
+}
+
+func TestSnapshot(t *testing.T) {
+	shot, err := Snapshot(sample(t), "storage", 96, 30, nil)
+	require.NoError(t, err)
+	assert.Contains(t, shot, "Enua 22/1 Wedding Cake", "Should render the screen it was asked for")
+
+	// The playback can be photographed mid-run, tick by tick.
+	shot, err = Snapshot(sample(t), "analysis", 96, 40, []string{"p", "tick"})
+	require.NoError(t, err)
+	assert.Contains(t, shot, "1/6", "Should apply the presses before the picture")
+
+	_, err = Snapshot(sample(t), "garage", 96, 30, nil)
+	assert.ErrorContains(t, err, "no screen called", "Should name the screens that exist")
+
+	_, err = Snapshot(sample(t), "journal", 96, 30, []string{"ctrl+alt+del"})
+	assert.ErrorContains(t, err, "cannot press", "Should refuse a key it cannot spell")
 }


### PR DESCRIPTION
# Pull request

## What and why

A gift-shaped tool, round two. Every pull request capture so far was a throwaway test written, run, scraped and deleted — six times in one day — and every thought about a new client began with wondering how to get at the fold's numbers without scraping a terminal. `witsnap` is both answers in one binary:

- **`witsnap screens`** renders any screen as plain text through the newly exported `tui.Snapshot` seam: `--screen storage --press p,tick,tick` photographs a replay mid-run, because `tick` is a key it knows how to press. What it prints is what wits shows, because it drives the same model keystroke by keystroke.
- **`witsnap json`** writes the derived state as JSON — balances, cycles (carried-over and all), the current cycle's runway, per-day grind/sesh series, device usage. This is the contract a future `wits-server`, web UI, or one-off chart experiment starts from, without touching the TUI.

`make snap` builds it. `tui.Snapshot` and `tui.ScreenNames` are the exported seam; `stripANSI` moved out of the test file to serve both.

## How it was verified

`make preflight` passes end to end. `tui.Snapshot` has its own tests (renders the named screen, applies presses including ticks, names the screens on a bad name, refuses keys it cannot spell). Smoke-tested against the seeded demo repo: a mid-replay storage capture and a JSON dump cross-checked for events, remaining grams, device usage and day count.

## Checklist

- [x] Tests cover the change
- [x] `make test` and `make vet` pass
- [x] Documentation (README, Makefile) still tells the truth

## Screens

Captured by the tool this PR adds — `witsnap screens --screen stash --press p,tick,tick,tick,tick,tick`:

<details>
<summary>Stash mid-replay (witsnap capture)</summary>

```text
 🥦 wits    Dashboard    Journal    Analysis    Storage    Stash    Sessions    Devices             
────────────────────────────────────────────────────────────────────────────────────────────────────
 holding · 2   finished · 0                                                                         
 ▶ 5/41 · playing · 5.0 events/s · p pause · ←/→ step · +/- speed                                   
 →        ◆ ground      0.70g  Enua 22/1 Wedding Cake                                               
                                                                                                    
 Stash ───────────────────────────────────────────────────────────────────────────────────────────  
    PRODUCT                        THC/CBD     STASH    THROUGH    SESSIONS    LAST USED            
 │☐ Enua 22/1 Wedding Cake            22/1    1.55 g     1.55 g           0  12 Jun 2026            
  ☐ Cannamedical 28/1 Lemon Cookie    28/1    1.10 g     1.10 g           0  11 Jun 2026            
                                                                                                    
 Consumed ────────────────────────────────────────────────────────────────────────────────────────  
   no stash finished yet                                                                            
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
────────────────────────────────────────────────────────────────────────────────────────────────────
 ↑/k up • ↓/j down • space mark • r weigh • e edit • p play/pause • ? help • q quit                 
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
