### PR TITLE
Replay: adjustments ride along silently

### DIFF
--- a/pkg/tui/analysis.go
+++ b/pkg/tui/analysis.go
@@ -84,7 +84,7 @@ func (v analysisView) Update(msg tea.Msg, a *App) (analysisView, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case playTickMsg:
-		v.player, cmd = v.player.advance(len(v.events(a)))
+		v.player, cmd = v.player.advance(v.events(a))
 		return v, cmd
 	case tea.KeyPressMsg:
 		switch {
@@ -93,10 +93,10 @@ func (v analysisView) Update(msg tea.Msg, a *App) (analysisView, tea.Cmd) {
 			v.scroll, v.player = 0, newPlayer()
 			v.speed = 2
 		case key.Matches(msg, playKey):
-			v.player, cmd = v.player.toggle(len(v.events(a)))
+			v.player, cmd = v.player.toggle(v.events(a))
 			return v, cmd
 		case key.Matches(msg, slideKey):
-			v.player = v.player.step(msg, len(v.events(a)))
+			v.player = v.player.step(msg, v.events(a))
 		case key.Matches(msg, speedKeys):
 			v.player = v.player.retune(msg)
 		case key.Matches(msg, a.keys.Up):
@@ -114,17 +114,24 @@ func (v analysisView) Update(msg tea.Msg, a *App) (analysisView, tea.Cmd) {
 	return v, nil
 }
 
+// skippable reports whether an event rides along silently in a replay rather
+// than getting a frame of its own. Adjustments are corrections — reconciled
+// scales, cleaned history — and a replay narrating each one reads as spam
+// while the bars barely move. They are still applied with the prefix, so the
+// balances stay true; they just never take the stage.
+func skippable(e journal.Event) bool { return e.Type == journal.Adjust }
+
 // toggle starts the replay — from the beginning when the screen was live or
 // already played out — or pauses one that is running.
-func (p player) toggle(total int) (player, tea.Cmd) {
+func (p player) toggle(events []journal.Event) (player, tea.Cmd) {
 	if p.playing {
 		p.playing = false
 		return p, nil
 	}
-	if total == 0 {
+	if len(events) == 0 {
 		return p, nil
 	}
-	if p.playhead < 0 || p.playhead >= total {
+	if p.playhead < 0 || p.playhead >= len(events) {
 		p.playhead = 0
 	}
 	p.playing = true
@@ -132,13 +139,17 @@ func (p player) toggle(total int) (player, tea.Cmd) {
 }
 
 // advance applies the next event of a running playback and schedules the one
-// after it, settling back to live when the record runs out.
-func (p player) advance(total int) (player, tea.Cmd) {
+// after it, swallowing the skippable ones so every frame shows a real event,
+// and settling back to live when the record runs out.
+func (p player) advance(events []journal.Event) (player, tea.Cmd) {
 	if !p.playing {
 		return p, nil
 	}
 	p.playhead++
-	if p.playhead >= total {
+	for p.playhead < len(events) && skippable(events[p.playhead-1]) {
+		p.playhead++
+	}
+	if p.playhead >= len(events) {
 		p.playhead, p.playing = -1, false
 		return p, nil
 	}
@@ -146,8 +157,10 @@ func (p player) advance(total int) (player, tea.Cmd) {
 }
 
 // step moves the playback by hand, pausing it: right applies the next event,
-// left takes the last one back. Stepping past the end settles on live.
-func (p player) step(msg tea.KeyPressMsg, total int) player {
+// left takes the last one back, both passing over the skippable ones the way
+// the clock does. Stepping past the end settles on live.
+func (p player) step(msg tea.KeyPressMsg, events []journal.Event) player {
+	total := len(events)
 	if total == 0 {
 		return p
 	}
@@ -157,9 +170,16 @@ func (p player) step(msg tea.KeyPressMsg, total int) player {
 		at = total
 	}
 	if msg.String() == "left" || msg.String() == "h" {
-		at = max(at-1, 0)
+		at--
+		for at > 0 && skippable(events[at-1]) {
+			at--
+		}
+		at = max(at, 0)
 	} else {
 		at++
+		for at < total && skippable(events[at-1]) {
+			at++
+		}
 	}
 	if at >= total {
 		p.playhead = -1
@@ -205,17 +225,35 @@ func (p player) transport(a *App, events []journal.Event, width int) string {
 	if p.playing {
 		mark, state = "▶", "playing"
 	}
+	// The counter counts the events worth a frame; the adjustments riding
+	// along silently are not part of the story being told.
 	line := lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Render(mark+" ") +
-		t.Value.Render(fmt.Sprintf("%d/%d", p.playhead, len(events))) +
+		t.Value.Render(fmt.Sprintf("%d/%d", shown(events[:min(p.playhead, len(events))]), shown(events))) +
 		t.Dim.Render(fmt.Sprintf(" · %s · %.1f events/s · p %s · ←/→ step · +/- speed",
 			state, 1000/float64(playSpeeds[p.speed].Milliseconds()),
 			map[bool]string{true: "pause", false: "play"}[p.playing]))
-	if p.playhead > 0 {
-		e := events[p.playhead-1]
+	// Narrate the newest event that took the stage, never a silent one.
+	for at := min(p.playhead, len(events)); at > 0; at-- {
+		if skippable(events[at-1]) {
+			continue
+		}
+		e := events[at-1]
 		line += "\n" + t.Dim.Render("→ ") +
 			t.entryLine(e, a.data.ProductName(e.Product), width-2, false, false, false)
+		break
 	}
 	return line
+}
+
+// shown counts the events of a run that a replay gives a frame to.
+func shown(events []journal.Event) int {
+	n := 0
+	for _, e := range events {
+		if !skippable(e) {
+			n++
+		}
+	}
+	return n
 }
 
 func (v analysisView) View(a *App, height int) string {

--- a/pkg/tui/products.go
+++ b/pkg/tui/products.go
@@ -105,16 +105,16 @@ func (v storageView) Update(msg tea.Msg, a *App) (storageView, tea.Cmd) {
 	rows := v.rows(a)
 	var cmd tea.Cmd
 	if _, ok := msg.(playTickMsg); ok {
-		v.player, cmd = v.player.advance(len(a.data.State.Events))
+		v.player, cmd = v.player.advance(a.data.State.Events)
 		return v, cmd
 	}
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
 		switch {
 		case key.Matches(msg, playKey):
-			v.player, cmd = v.player.toggle(len(a.data.State.Events))
+			v.player, cmd = v.player.toggle(a.data.State.Events)
 			return v, cmd
 		case key.Matches(msg, slideKey):
-			v.player = v.player.step(msg, len(a.data.State.Events))
+			v.player = v.player.step(msg, a.data.State.Events)
 		case key.Matches(msg, speedKeys):
 			v.player = v.player.retune(msg)
 		case key.Matches(msg, a.keys.Up):
@@ -669,16 +669,16 @@ func (v stashView) Update(msg tea.Msg, a *App) (stashView, tea.Cmd) {
 	slugs := v.slugsInOrder(a)
 	var cmd tea.Cmd
 	if _, ok := msg.(playTickMsg); ok {
-		v.player, cmd = v.player.advance(len(a.data.State.Events))
+		v.player, cmd = v.player.advance(a.data.State.Events)
 		return v, cmd
 	}
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
 		switch {
 		case key.Matches(msg, playKey):
-			v.player, cmd = v.player.toggle(len(a.data.State.Events))
+			v.player, cmd = v.player.toggle(a.data.State.Events)
 			return v, cmd
 		case key.Matches(msg, slideKey):
-			v.player = v.player.step(msg, len(a.data.State.Events))
+			v.player = v.player.step(msg, a.data.State.Events)
 		case key.Matches(msg, speedKeys):
 			v.player = v.player.retune(msg)
 		case key.Matches(msg, a.keys.Up):

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -309,3 +309,54 @@ func TestSnapshot(t *testing.T) {
 	_, err = Snapshot(sample(t), "journal", 96, 30, []string{"ctrl+alt+del"})
 	assert.ErrorContains(t, err, "cannot press", "Should refuse a key it cannot spell")
 }
+
+func TestReplaySkipsAdjustments(t *testing.T) {
+	// A record with a correction in the middle: purchase, grind, adjust,
+	// grind. The adjustment must ride along silently.
+	at := time.Date(2026, time.July, 9, 10, 0, 0, 0, time.UTC)
+	mk := func(typ journal.Type, grams float64, day int) journal.Event {
+		from, to, _ := journal.Flow(typ)
+		return journal.Event{Type: typ, Product: "wcake", Grams: grams, From: from, To: to,
+			OccurredAt: at.AddDate(0, 0, day)}
+	}
+	events := []journal.Event{
+		mk(journal.Purchase, 20, 0),
+		mk(journal.Grind, 1, 1),
+		mk(journal.Adjust, 0.5, 2),
+		mk(journal.Grind, 1, 3),
+	}
+	products := &catalog.Catalog{}
+	require.NoError(t, products.Add(product("Enua 22/1 Wedding Cake", "wcake")))
+	data := Data{Workspace: &workspace.Workspace{
+		Products: products, Devices: &catalog.Devices{}, State: ledger.Fold(events),
+	}, Now: at.AddDate(0, 0, 4)}
+
+	app := New(data)
+	app.screen = analysisScreen
+	app.analysis.scope = 4 // all time
+	var m tea.Model = app
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 96, Height: 40})
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	out := stripANSI(m.View().Content)
+	assert.Contains(t, out, "0/3", "The counter should not count the adjustment")
+
+	// Two ticks: purchase, then grind.
+	m, _ = m.Update(playTickMsg{})
+	m, _ = m.Update(playTickMsg{})
+	assert.Equal(t, 2, app.analysis.playhead, "Two ticks apply the first two events")
+	out = stripANSI(m.View().Content)
+	assert.Contains(t, out, "2/3", "still not counting the adjustment")
+	assert.Contains(t, out, "ground", "and narrating the grind")
+	assert.NotContains(t, out, "adjusted", "never the adjustment")
+
+	m, _ = m.Update(playTickMsg{})
+	assert.Equal(t, -1, app.analysis.playhead,
+		"The next tick swallows the adjustment, reaches the end, and settles on live")
+
+	// Stepping back from live passes over the adjustment the same way.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, 2, app.analysis.playhead, "Left from live lands before the adjustment, not on it")
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, 1, app.analysis.playhead, "and keeps walking real events")
+}


### PR DESCRIPTION
# Pull request

## What and why

A replay narrating every correction reads as spam: reconciled scales and cleaned history each took a frame while the bars barely moved. Adjustments now ride along silently, on all three replaying screens at once, since the behaviour lives in the shared `player`:

- The clock and the hand-steps (`←`/`→`) pass over `adjust` events in either direction — every frame shows a real event.
- The counter counts only the events worth a frame: a 43-event ledger with two corrections reads `…/41`.
- The narration line always names a real event, never an adjustment.
- The adjustments are **still applied** with the prefix, so the balances stay historically true — they just never take the stage.

## How it was verified

`make preflight` passes. A new test replays a record with a correction in the middle: the counter excludes it, ticks and steps swallow it in both directions, the narration never says "adjusted", and reaching the end still settles on live. Also verified against a seeded repo with two reconciliations, captured below by witsnap.

## Checklist

- [x] Tests cover the change
- [x] `make test` and `make vet` pass
- [x] Documentation still tells the truth

## Screens

Captured with `witsnap screens --screen storage --press p,tick,tick,tick` against a 43-event repo containing two adjustments — the counter reads /41:

<details>
<summary>Storage mid-replay, adjustments silent (witsnap capture)</summary>

```text
 🥦 wits    Dashboard    Journal    Analysis    Storage    Stash    Sessions    Devices             
────────────────────────────────────────────────────────────────────────────────────────────────────
 on the shelf · 2   history · 0                                                                     
 ▶ 3/41 · playing · 5.0 events/s · p pause · ←/→ step · +/- speed                                   
 →        ◆ ground      0.85g  Enua 22/1 Wedding Cake                                               
                                                                                                    
 Storage ─────────────────────────────────────────────────────────────────────────────────────────  
    PRODUCT                        THC/CBD   STORAGE     STASH       AVB     GROUND                 
 │☐ Enua 22/1 Wedding Cake            22/1    9.15 g    0.85 g    0.00 g     0.85 g                 
   Enua · Wedding Cake · last used 10 Jun 2026                                                      
   ████████████████████████████████████████████████████ 10.00 g of 10.00 g dispensed still held     
   press space to mark, r to weigh, e to edit                                                       
                                                                                                    
  ☐ Cannamedical 28/1 Lemon Cookie    28/1   10.00 g    0.00 g    0.00 g     0.00 g                 
                                                                                                    
 History ─────────────────────────────────────────────────────────────────────────────────────────  
    PRODUCT                        THC/CBD    BOUGHT     GROUND    LAST USED                        
   nothing weighed down to zero yet                                                                 
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
                                                                                                    
────────────────────────────────────────────────────────────────────────────────────────────────────
 ↑/k up • ↓/j down • space mark • r weigh • e edit • c clean history • p play/pause • ? help • q qui
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
