### PR TITLE
Skip coverage uploads where secrets are withheld

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,12 +39,18 @@ jobs:
       - name: Test
         run: make test-ci
 
+      # The coverage uploads need repository secrets, which GitHub withholds
+      # from Dependabot and fork pull requests. Skipping them there keeps the
+      # build honest — a genuine code failure still fails — while a secret-less
+      # run does not show a false red for a token it was never given.
       - name: Upload coverage reports to Codecov
+        if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run codacy-coverage-reporter
+        if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
         uses: codacy/codacy-coverage-reporter-action@6904bd01e29ada115135b5eca20125758ccae53b
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
# Pull request

## What and why

The last Dependabot pull request showed a red **build** that had nothing to do with the code: Go build, vet, tests and gofmt all passed, but the `codacy-coverage-reporter` step failed on `Invalid configuration: … API token must be provided`. GitHub deliberately withholds repository secrets from Dependabot and fork pull requests, so both coverage-*upload* steps run without their token and error.

With the dependency updates now **grouped** (weekly Charm / `golang.org/x` batches), that false red would appear on every one. This guards both upload steps:

```yaml
if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
```

so they run on pushes and same-repo pull requests — where the secrets exist — and skip on Dependabot and forks. A genuine build, vet or test failure still fails the job; a secret-less run just stops lying about a token it was never given. (`secrets` cannot be read in an `if:`, so the actor/fork check is the standard idiom.)

## How it was verified

`python3 -c 'yaml.safe_load(...)'` and `actionlint` both pass on the workflow. The change is CI-only; the Go build and tests are unchanged.

## Checklist

- [x] Documentation still tells the truth (the step comment explains the guard)
- [x] Workflow validated with actionlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)