### PR TITLE
fix(tui): keep the clean-history question on screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMMIT_DATE = $(shell git --no-pager log -1 --pretty='format:%cd' --date='format
 PKG = github.com/TheDonDope/wits/pkg/version
 LDFLAGS = -X $(PKG).Version=$(VERSION) -X $(PKG).CommitSHA=$(COMMIT_SHA) -X $(PKG).CommitDate=$(COMMIT_DATE)
 
-.PHONY: run install build build-windows clean doc changelog render-tapes \
+.PHONY: run install install-wits build build-windows clean doc changelog render-tapes \
 	test test-ci cover show-cover vet preflight snap release
 
 .DEFAULT_GOAL := build
@@ -22,6 +22,13 @@ install:
 	go install github.com/charmbracelet/freeze@latest
 	go install github.com/charmbracelet/gum@latest
 	go install github.com/charmbracelet/vhs@latest
+
+# The working tree, installed where `go install …@latest` would put a release:
+# $GOBIN, or $GOPATH/bin when GOBIN is unset. Stamped through the same ldflags
+# as `make build`, so --version names the commit rather than confessing
+# "unknown (built from source)".
+install-wits:
+	go install -ldflags "$(LDFLAGS)" ./cmd/wits
 
 build:
 	go build \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ with none all work without special cases.
 go install github.com/TheDonDope/wits/cmd/wits@latest
 ```
 
+From a checkout, `make install-wits` installs the working tree to the same
+place instead — see [Development](#development).
+
 A repository is created the way a git one is, and every command finds it by
 walking up from the working directory.
 
@@ -94,7 +97,28 @@ mac1-251    15.00 g · Cantourage 25/1 MAC1+
 wcake-221   18.00 g · Enua 22/1 Wedding Cake
 ```
 
-Install it with `wits completion bash` (or `zsh`, `fish`).
+Completion is a script the shell sources, written by `wits completion bash`
+(or `zsh`, `fish`). Bash only runs it through the `bash-completion` package,
+which is not always preinstalled — without it the script loads silently and
+does nothing. Install that first, give it the directory it reads user
+completions from, and write the script there:
+
+```sh
+sudo pacman -S bash-completion   # or apt/dnf install bash-completion,
+                                 # brew install bash-completion@2
+mkdir -p ~/.local/share/bash-completion/completions
+wits completion bash > ~/.local/share/bash-completion/completions/wits
+```
+
+A new shell picks it up from there; nothing needs sourcing in `.bashrc`, and
+no `sudo` was involved. To try it in the current shell without writing
+anything: `source <(wits completion bash)`. Zsh wants the script on its
+`fpath` as `_wits`, fish in its own completions directory:
+
+```sh
+wits completion zsh > "${fpath[1]}/_wits"                    # zsh
+wits completion fish > ~/.config/fish/completions/wits.fish  # fish
+```
 
 Anything can be backdated with `--date 2026-07-29`, which is what makes a
 forgotten evening loggable the next morning without pretending it was entered
@@ -331,13 +355,23 @@ in one binary, which shows up on screen as inconsistent colour.
 ## Development
 
 ```sh
-make build      # build ./bin/wits
-make run        # build it and run it
-make test       # test with coverage
-make cover      # coverage as HTML
+make build         # build ./bin/wits
+make run           # build it and run it
+make install-wits  # install the working tree as `wits`, replacing a release
+make test          # test with coverage
+make cover         # coverage as HTML
 make vet
-make preflight  # everything CI and the Codacy gate will say, said here first
+make preflight     # everything CI and the Codacy gate will say, said here first
 ```
+
+`make build` writes to `./bin/wits`, which is fine for a session in the
+checkout and wrong for daily use — the shell keeps finding whatever `wits` is
+on the PATH. `make install-wits` installs the working tree where
+`go install …@latest` puts a release: `$GOBIN`, or `$GOPATH/bin` when GOBIN is
+unset (`go env GOPATH` says which). It goes through the same ldflags as
+`make build`, so `wits --version` names the tag and commit it was built from;
+a bare `go install ./cmd/wits` skips the stamp and reports
+`unknown (built from source)`.
 
 `./preflight.sh watch <pr>` polls a pull request's checks and reads the Codacy
 delta the way the gate does, so a red X never comes as a surprise.

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -678,15 +678,55 @@ func Snapshot(data Data, screenName string, width, height int, presses []string)
 	app := New(data)
 	app.screen = screen(at)
 	var m tea.Model = app
-	m, _ = m.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	m = deliver(m, tea.WindowSizeMsg{Width: width, Height: height})
 	for _, press := range presses {
 		msg, err := pressFor(press)
 		if err != nil {
 			return "", err
 		}
-		m, _ = m.Update(msg)
+		m = deliver(m, msg)
 	}
 	return stripANSI(m.View().Content), nil
+}
+
+// deliver sends a message and drains the commands it produces, the way the
+// runtime does. huh moves between fields by returning a command, so a snapshot
+// that dropped them would photograph every form frozen before its first field.
+func deliver(m tea.Model, msg tea.Msg) tea.Model {
+	msgs := []tea.Msg{msg}
+	for steps := 0; len(msgs) > 0 && steps < 128; steps++ {
+		next := msgs[0]
+		msgs = msgs[1:]
+		if batch, ok := next.(tea.BatchMsg); ok {
+			for _, cmd := range batch {
+				if out := promptly(cmd); out != nil {
+					msgs = append(msgs, out)
+				}
+			}
+			continue
+		}
+		var cmd tea.Cmd
+		m, cmd = m.Update(next)
+		if cmd != nil {
+			if out := promptly(cmd); out != nil {
+				msgs = append(msgs, out)
+			}
+		}
+	}
+	return m
+}
+
+// promptly runs a command, abandoning one that does not answer at once — a
+// cursor blink waits on a timer, and a snapshot has no interest in it.
+func promptly(cmd tea.Cmd) tea.Msg {
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		return msg
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	}
 }
 
 // pressFor turns a spelled-out key into the message the runtime would send.

--- a/pkg/tui/entry.go
+++ b/pkg/tui/entry.go
@@ -514,13 +514,29 @@ const entryCleanHistory entryKind = iota + 500
 func newCleanHistoryForm(slugs []string, a *App) *entryForm {
 	f := &entryForm{kind: entryCleanHistory, slugs: slugs}
 
+	// The confirmation has to stay on screen. A workbook import leaves dozens
+	// of stale jars, and listing them all pushed the question below the fold —
+	// the form answered enter with its default, Keep, and looked like it did
+	// nothing. What does not fit folds into one line; the storage screen is
+	// the full listing.
+	room := max(3, a.height-20)
 	var listed []string
-	total := 0.0
+	total, folded, foldedGrams := 0.0, 0, 0.0
 	for _, slug := range slugs {
-		if b := a.data.State.Balances[slug]; b != nil {
-			listed = append(listed, fmt.Sprintf("%s — %.2f g", a.data.ProductName(slug), b.Stash))
-			total += b.Stash
+		b := a.data.State.Balances[slug]
+		if b == nil {
+			continue
 		}
+		total += b.Stash
+		if len(listed) < room {
+			listed = append(listed, fmt.Sprintf("%s — %.2f g", a.data.ProductName(slug), b.Stash))
+		} else {
+			folded++
+			foldedGrams += b.Stash
+		}
+	}
+	if folded > 0 {
+		listed = append(listed, fmt.Sprintf("… and %d more, %.2f g together", folded, foldedGrams))
 	}
 	f.form = huh.NewForm(huh.NewGroup(
 		huh.NewNote().Title(fmt.Sprintf("Clean history — %s, %.2f g", plural(len(slugs), "jar"), total)).

--- a/pkg/tui/products_test.go
+++ b/pkg/tui/products_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -223,6 +224,57 @@ func TestCleanHistoryOffersAndRecords(t *testing.T) {
 	reloaded, err := Load(app.data.Repo)
 	require.NoError(t, err)
 	assert.Zero(t, reloaded.State.Balances["lemon"].Stash, "The stash should be zero afterwards")
+}
+
+// TestCleanHistoryManyJars is the imported-workbook shape: dozens of stale
+// stashes. The dialog must keep its confirmation on screen — listing every
+// jar once pushed it below the fold, where enter answered with the default
+// Keep and the clean-up looked like it did nothing.
+func TestCleanHistoryManyJars(t *testing.T) {
+	r, err := repo.Init(t.TempDir())
+	require.NoError(t, err)
+	data, err := Load(r)
+	require.NoError(t, err)
+	rec := record.New(r, data.Products, data.Devices, data.State)
+
+	for i := 0; i < 40; i++ {
+		slug := fmt.Sprintf("old%02d", i)
+		_, _, _, err = rec.Buy(fmt.Sprintf("Maker %d/1 Old Strain %d", 20+i%10, i), slug, 10, time.Now().AddDate(0, 0, -400+i*2))
+		require.NoError(t, err)
+		_, err = rec.Grind(slug, 10, time.Now().AddDate(0, 0, -399+i*2))
+		require.NoError(t, err)
+	}
+	_, _, _, err = rec.Buy("Enua 22/1 Wedding Cake", "wcake", 20, time.Now())
+	require.NoError(t, err)
+
+	data, err = Load(r)
+	require.NoError(t, err)
+	app := New(data)
+	app.screen = storageScreen
+	app.width, app.height = 120, 40
+	var m tea.Model = app
+
+	m, _ = send(m, tea.KeyPressMsg{Code: 'c', Text: "c"})
+	require.NotNil(t, app.entry, "c should open the confirmation")
+
+	view := stripANSI(app.entry.View(app, 118))
+	lines := strings.Count(view, "\n") + 1
+	assert.LessOrEqual(t, lines, app.height-2, "The dialog must fit under the tab bar")
+	assert.Contains(t, view, "Record them as consumed?", "with the question on screen")
+	assert.Contains(t, view, "more,", "and the jars that did not fit folded into one line")
+	assert.Contains(t, view, "400.00 g", "counting every jar in the total, listed or folded")
+
+	// Choose Clean and submit, the way a user would.
+	m, _ = send(m, tea.KeyPressMsg{Code: tea.KeyLeft})
+	_, msgs := send(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	done, ok := findDone(msgs)
+	require.True(t, ok, "enter should submit the confirmation")
+	require.NoError(t, done.err)
+	assert.Contains(t, done.summary, "cleaned 40 stashes")
+
+	reloaded, err := Load(r)
+	require.NoError(t, err)
+	assert.Zero(t, reloaded.State.Balances["old17"].Stash, "The stale stashes are zeroed")
 }
 
 func TestCleanHistoryDeclined(t *testing.T) {


### PR DESCRIPTION
## What

Found in the storage-tab sparring review, on a fresh repo with the cleaned workbook imported: pressing `c` (clean history) appeared to do nothing, and the two-table view never filled its history.

Two bugs, one visible and one behind it:

- **The dialog outgrew the terminal.** Forty stale jars made the confirmation panel ~57 rows tall, so the `Clean / Keep` question sat below the fold. Enter answered with the default — Keep — and cancelled silently. The jar list now folds what does not fit into "… and N more, M g together"; the storage screen is the full listing anyway, and the total in the title still counts every jar.
- **witsnap photographed forms frozen.** `Snapshot` dropped the commands an update returns, and huh moves between fields by returning a command — so every snapshotted form rendered blank on first paint. Snapshot now drains commands the way the runtime does, abandoning ones that block on a timer.

## How it reads now

```
│   Cannamedical Sativa Forte 24/1 Amsterdam Amnesia — 10.00 g  │
│   … and 20 more, 384.00 g together                            │
│                                                               │
│   Each stash is reconciled to zero: the grams were consumed…  │
│ ┃ Record them as consumed?                                    │
│ ┃     Clean     Keep                                          │
│ ←/→ toggle • enter submit • y Clean • n Keep                  │
```

Confirming against the imported workbook: shelf · 10, history · 40.

## Tests

`TestCleanHistoryManyJars` reproduces the imported-workbook shape — forty stale jars at a 40-row terminal — and asserts the dialog fits with the question on screen, then walks the keyboard path (`c`, `←`, `enter`) through to the zeroed stashes. The prior tests only ever cleaned one jar, and confirmed by setting the flag in code rather than through the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)