### PR TITLE
fix(ledger): bill the fill, not the shelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,19 +126,26 @@ then.
 
 ```console
 $ wits status
-On cycle 29, opened 2026-07-09 (day 24)
+On cycle 29, opened 2026-07-09 (day 26)
 
 PRODUCT                           STORAGE  STASH   AVB    LEFT
 420-evolution-ice-cream-cake-271  16.90g   3.10g   0.00g  84%
 enua-citrus-slap-361              17.09g   2.91g   0.00g  85%
-cantourage-mac1-251               17.23g   47.77g  0.00g  86%
+cantourage-mac1-251               17.23g   47.77g  0.00g  75%
 
-total                             41.00g                  68%
+total                             51.22g                  81%
 
-41.00g of 60.00g left over 23 days, 11 of them with an entry
+51.22g of 62.95g left over 23 days, 11 of them with an entry
+15.82g more still on the shelf, carried from earlier cycles in 7 older jars
 1.73g per active day, 1.37g median, 0.83g per elapsed day
-About 24 days left at that rate
+About 30 days left at that rate
 ```
+
+The total is the fill's: the jars this cycle dispensed into, over what they
+started with — which includes what one of them still held when the same
+product was refilled. What earlier cycles left in *other* jars is reported on
+its own line rather than folded into the arithmetic, so the sum on top is
+always the sum of the rows above it.
 
 `wits` on its own opens the interface: a dashboard of cards — storage, stash,
 sessions, devices, two rhythm calendars and a projection of the supply's

--- a/cmd/wits/commands/export.go
+++ b/cmd/wits/commands/export.go
@@ -84,8 +84,12 @@ func writeMarkdown(out io.Writer, cycles []ledger.Cycle, products *catalog.Catal
 		fmt.Fprintln(out, "| | |")
 		fmt.Fprintln(out, "| --- | --- |")
 		fmt.Fprintf(out, "| Purchased | %.2f g |\n", c.Purchased)
+		if c.Carried > 0 {
+			fmt.Fprintf(out, "| Carried in from earlier | %.2f g |\n", c.Carried)
+		}
 		fmt.Fprintf(out, "| Ground | %.2f g |\n", c.Ground)
-		fmt.Fprintf(out, "| Remaining | %.2f g (%.0f%%) |\n", c.Remaining(), c.RemainingPct()*100)
+		fmt.Fprintf(out, "| Remaining of the fill | %.2f g (%.0f%%) |\n",
+			c.FillRemaining(), c.FillRemainingPct()*100)
 		fmt.Fprintf(out, "| Days elapsed | %d |\n", stats.ElapsedDays)
 		fmt.Fprintf(out, "| Days with an entry | %d |\n", stats.ActiveDays)
 		fmt.Fprintf(out, "| Per active day | %.2f g |\n", stats.PerActiveDay)

--- a/cmd/wits/commands/status.go
+++ b/cmd/wits/commands/status.go
@@ -62,20 +62,22 @@ func writeStatus(out io.Writer, state *ledger.State) {
 		fmt.Fprintf(w, "%s\t%.2fg\t%.2fg\t%.2fg\t%s\n",
 			product, b.Storage, b.Stash, b.AVB, percent(b.Storage, heldOf(cycle, product, state)))
 	}
+	remaining := state.FillOnShelf(cycle)
 	fmt.Fprintf(w, "\t\t\t\t\n")
-	fmt.Fprintf(w, "total\t%.2fg\t\t\t%s\n", cycle.Remaining(), percent(cycle.Remaining(), cycle.Held()))
+	fmt.Fprintf(w, "total\t%.2fg\t\t\t%s\n", remaining, percent(remaining, cycle.Fill()))
 	w.Flush()
 
 	fmt.Fprintf(out, "\n%.2fg of %.2fg left over %s, %d of them with an entry\n",
-		cycle.Remaining(), cycle.Held(), plural(stats.ElapsedDays, "day"), stats.ActiveDays)
-	if cycle.Carried > 0 {
-		fmt.Fprintf(out, "%.2fg of that was carried over from the cycle before\n", cycle.Carried)
+		remaining, cycle.Fill(), plural(stats.ElapsedDays, "day"), stats.ActiveDays)
+	if carried, jars := state.CarriedOnShelf(cycle); carried > 0 {
+		fmt.Fprintf(out, "%.2fg more still on the shelf, carried from earlier cycles in %s\n",
+			carried, plural(jars, "older jar"))
 	}
 	if stats.PerActiveDay > 0 {
 		fmt.Fprintf(out, "%.2fg per active day, %.2fg median, %.2fg per elapsed day\n",
 			stats.PerActiveDay, stats.MedianPerDay, stats.PerElapsedDay)
 		fmt.Fprintf(out, "About %s left at that rate\n",
-			plural(int(math.Round(stats.DaysLeft(cycle.Remaining()))), "day"))
+			plural(int(math.Round(stats.DaysLeft(remaining))), "day"))
 	} else {
 		fmt.Fprintln(out, "Nothing ground yet this cycle, so there is no rate to extrapolate from")
 	}

--- a/cmd/witsnap/main.go
+++ b/cmd/witsnap/main.go
@@ -105,11 +105,15 @@ type state struct {
 	Devices     []deviceUse                `json:"device_usage"`
 }
 
+// currentCycle is scoped to the fill: held and remaining count the cycle's
+// own jars, and what earlier cycles left in other jars reports separately.
 type currentCycle struct {
 	Start        time.Time `json:"start"`
 	Held         float64   `json:"held"`
 	Remaining    float64   `json:"remaining"`
 	RemainingPct float64   `json:"remaining_pct"`
+	CarriedGrams float64   `json:"carried_grams,omitempty"`
+	CarriedJars  int       `json:"carried_jars,omitempty"`
 	PerActiveDay float64   `json:"per_active_day"`
 	DaysLeft     float64   `json:"days_left"`
 }
@@ -170,13 +174,22 @@ func current(ws *workspace.Workspace) *currentCycle {
 		return nil
 	}
 	stats := ledger.Summarise(c.Events)
+	remaining := ws.State.FillOnShelf(c)
+	held := c.Fill()
+	pct := 0.0
+	if held > 0 {
+		pct = remaining / held
+	}
+	carried, jars := ws.State.CarriedOnShelf(c)
 	return &currentCycle{
 		Start:        c.Start,
-		Held:         c.Held(),
-		Remaining:    c.Remaining(),
-		RemainingPct: c.RemainingPct(),
+		Held:         held,
+		Remaining:    remaining,
+		RemainingPct: pct,
+		CarriedGrams: carried,
+		CarriedJars:  jars,
 		PerActiveDay: stats.PerActiveDay,
-		DaysLeft:     stats.DaysLeft(c.Remaining()),
+		DaysLeft:     stats.DaysLeft(remaining),
 	}
 }
 

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -98,6 +98,49 @@ func (c Cycle) HeldOf(slug string) float64 {
 	return Round(c.PurchasedOf(slug) + c.Opening[slug])
 }
 
+// GroundOf returns the grams of one product ground during the cycle.
+func (c Cycle) GroundOf(slug string) float64 {
+	var grams float64
+	for _, e := range c.Events {
+		if e.Product == slug && e.Type == journal.Grind {
+			grams += e.Grams
+		}
+	}
+	return Round(grams)
+}
+
+// Fill returns the grams the cycle's own jars started with: what the fill
+// dispensed, plus what those same jars still carried from an earlier fill of
+// the same product — grinding draws on the jar, not on one vintage in it.
+// The remainder sitting in other jars is the previous cycles' business and
+// is deliberately not counted; Held is the whole shelf, Fill is this fill.
+func (c Cycle) Fill() float64 {
+	var grams float64
+	for _, slug := range c.Products {
+		grams += c.HeldOf(slug)
+	}
+	return Round(grams)
+}
+
+// FillRemaining returns the grams of the fill's own jars not yet ground, by
+// the cycle's events. A live shelf can disagree by whatever a reconciliation
+// adjusted; a screen holding the balances should prefer State.FillOnShelf.
+func (c Cycle) FillRemaining() float64 {
+	remaining := c.Fill()
+	for _, slug := range c.Products {
+		remaining -= c.GroundOf(slug)
+	}
+	return Round(remaining)
+}
+
+// FillRemainingPct returns how much of the fill is left, from 0 to 1.
+func (c Cycle) FillRemainingPct() float64 {
+	if c.Fill() == 0 {
+		return 0
+	}
+	return c.FillRemaining() / c.Fill()
+}
+
 // Fold replays the events and returns the state they describe. Events are
 // folded in journal order, which is the order they were recorded in.
 func Fold(events []journal.Event) *State {
@@ -189,6 +232,38 @@ func (s *State) CurrentCycle() *Cycle {
 		return &s.Cycles[n-1]
 	}
 	return nil
+}
+
+// FillOnShelf returns the storage the cycle's own jars still hold: the live
+// counterpart of Cycle.FillRemaining, which also feels what reconciliation
+// adjusted after the fact.
+func (s *State) FillOnShelf(c *Cycle) float64 {
+	var grams float64
+	for _, slug := range c.Products {
+		if b, ok := s.Balances[slug]; ok {
+			grams += b.Storage
+		}
+	}
+	return Round(grams)
+}
+
+// CarriedOnShelf returns the storage still sitting outside the cycle's own
+// jars, and how many jars hold it — the previous cycles' remainder, which the
+// fill's arithmetic deliberately leaves out.
+func (s *State) CarriedOnShelf(c *Cycle) (float64, int) {
+	own := map[string]bool{}
+	for _, slug := range c.Products {
+		own[slug] = true
+	}
+	var grams float64
+	var jars int
+	for slug, b := range s.Balances {
+		if !own[slug] && b.Storage > 0 {
+			grams += b.Storage
+			jars++
+		}
+	}
+	return Round(grams), jars
 }
 
 // Stats summarises a run of events over time.

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -254,6 +254,40 @@ func TestCycleGap(t *testing.T) {
 		assert.Equal(t, 16.0, c.HeldOf("wedding-cake"), "Should give a product its fill plus its carry-over")
 	})
 
+	t.Run("TheFillIsNotTheShelf", func(t *testing.T) {
+		// The dashboard once billed the whole shelf to the current cycle: a
+		// fill of 40 read as "of 51" because eleven grams of older jars were
+		// still on the shelf, and the headline summed jars the card never
+		// listed. The fill counts its own jars — including what one of them
+		// still held from an earlier fill of the same product — and the older
+		// jars report separately.
+		s := Fold([]journal.Event{
+			event(journal.Purchase, "old-strain", 10, day(0)),
+			event(journal.Purchase, "wedding-cake", 10, day(0)),
+			event(journal.Grind, "old-strain", 2, day(5)),
+			event(journal.Grind, "wedding-cake", 7, day(6)),
+			// The next fill: a new product, and wedding-cake again with 3 g
+			// still in its jar. old-strain is not refilled.
+			event(journal.Purchase, "lemon-cookie", 20, day(30)),
+			event(journal.Purchase, "wedding-cake", 20, day(30)),
+			event(journal.Grind, "lemon-cookie", 5, day(35)),
+			event(journal.Grind, "wedding-cake", 4, day(36)),
+			event(journal.Grind, "old-strain", 1, day(37)),
+		})
+
+		require.Len(t, s.Cycles, 2)
+		c := &s.Cycles[1]
+		assert.Equal(t, 51.0, c.Held(), "The shelf: 40 filled + 11 carried")
+		assert.Equal(t, 43.0, c.Fill(), "The fill: 40 dispensed + 3 in wedding-cake's own jar")
+		assert.Equal(t, 34.0, c.FillRemaining(), "The fill minus its own jars' grinds, not old-strain's")
+		assert.InDelta(t, 34.0/43.0, c.FillRemainingPct(), 1e-9)
+
+		assert.Equal(t, 34.0, s.FillOnShelf(c), "Live storage of the fill's jars agrees, absent adjustments")
+		carried, jars := s.CarriedOnShelf(c)
+		assert.Equal(t, 7.0, carried, "old-strain's remainder stays the earlier cycles' business")
+		assert.Equal(t, 1, jars, "and it sits in one jar")
+	})
+
 	t.Run("SameDayFillsStayTogether", func(t *testing.T) {
 		s := Fold([]journal.Event{
 			event(journal.Purchase, "wedding-cake", 20, day(0)),

--- a/pkg/tui/dashboard.go
+++ b/pkg/tui/dashboard.go
@@ -139,12 +139,20 @@ func (d dashboard) quickActions(a *App, width int) string {
 func (d dashboard) storageCard(a *App, c *ledger.Cycle, w int) string {
 	t := a.theme
 	stats := ledger.Summarise(c.Events)
-	remaining := c.Remaining()
-	fraction := c.RemainingPct()
+
+	// The card is the fill's: the headline sums the same jars the rows below
+	// draw, over what this fill dispensed into them. Older jars still on the
+	// shelf get their own line rather than a share of the arithmetic.
+	remaining := a.data.State.FillOnShelf(c)
+	held := c.Fill()
+	fraction := 0.0
+	if held > 0 {
+		fraction = clamp(remaining/held, 0, 1)
+	}
 
 	headline := t.Big.Render(fmt.Sprintf("%.2f g", remaining)) +
 		t.Dim.Render(fmt.Sprintf("  of %.0f g · cycle %d (started: %s), day %d",
-			c.Held(), len(a.data.State.Cycles), c.Start.Format("2006-01-02"),
+			held, len(a.data.State.Cycles), c.Start.Format("2006-01-02"),
 			daysBetween(c.Start, a.data.Now)+1))
 	bar := GradientGauge(w, fraction, t.Good, t.Level(fraction), t.Dim)
 
@@ -156,6 +164,10 @@ func (d dashboard) storageCard(a *App, c *ledger.Cycle, w int) string {
 		headline,
 		bar,
 		t.Dim.Render(fmt.Sprintf("%s on the shelf · %s", plural(len(c.Products), "product"), runway)),
+	}
+	if carried, jars := a.data.State.CarriedOnShelf(c); carried > 0 {
+		lines = append(lines, t.Dim.Render(
+			fmt.Sprintf("+ %.2f g carried from earlier cycles in %s", carried, plural(jars, "older jar"))))
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, append(lines, d.storageRows(a, c, w)...)...)
 }

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -213,6 +213,45 @@ func TestDashboardStorageCardListsProducts(t *testing.T) {
 	assert.Contains(t, out, "Cannamedical 28/1", "all of them")
 }
 
+// TestDashboardBillsTheFillNotTheShelf pins the storage card to the fill's
+// own jars. It once summed every jar on the shelf into a headline over
+// fill-plus-carry-over, so the total never matched the rows drawn under it.
+func TestDashboardBillsTheFillNotTheShelf(t *testing.T) {
+	at := time.Date(2026, time.July, 9, 10, 0, 0, 0, time.UTC)
+	mk := func(typ journal.Type, product string, grams float64, day int) journal.Event {
+		from, to, _ := journal.Flow(typ)
+		return journal.Event{
+			Type: typ, Product: product, Grams: grams, From: from, To: to,
+			OccurredAt: at.AddDate(0, 0, day),
+		}
+	}
+	events := []journal.Event{
+		mk(journal.Purchase, "old", 10, -40),
+		mk(journal.Grind, "old", 2, -35),
+		mk(journal.Purchase, "wcake", 20, 0),
+		mk(journal.Grind, "wcake", 1, 1),
+	}
+	products := &catalog.Catalog{}
+	require.NoError(t, products.Add(product("Khiron 20/1 Old Strain", "old")))
+	require.NoError(t, products.Add(product("Enua 22/1 Wedding Cake", "wcake")))
+	data := Data{
+		Workspace: &workspace.Workspace{
+			Products: products,
+			Devices:  &catalog.Devices{},
+			State:    ledger.Fold(events),
+		},
+		Now: at.AddDate(0, 0, 2),
+	}
+
+	out := render(t, data, dashboardScreen, 110, 44)
+
+	assert.Contains(t, out, "19.00 g", "The headline sums the jars the card lists")
+	assert.Contains(t, out, "of 20 g", "over what the fill dispensed")
+	assert.NotContains(t, out, "of 28 g", "not the whole shelf")
+	assert.Contains(t, out, "+ 8.00 g carried from earlier cycles",
+		"with the previous cycles' remainder on its own line")
+}
+
 func TestDashboardWallClockAndCycleStart(t *testing.T) {
 	app := New(sample(t))
 	app.screen = dashboardScreen


### PR DESCRIPTION
## What

From the dashboard sparring round: the storage card said **67.04 g of 86 g** above three products summing to 51.22 g. Both numbers were "correct" — for the whole shelf. `Held()` is fill + carry-over (60 + 26.04 in ten older jars), `Remaining()` subtracts every grind of the cycle including grinds of those older jars. The carry-over fix (9bd80bb) was guarding per-product percentages from reading over 100% and overshot: it billed the whole shelf to a fill that never dispensed most of it.

## How

A cycle now distinguishes the **shelf** from the **fill**:

- `Cycle.Fill()` — what the fill dispensed **plus what those same jars still carried** from an earlier fill of the same product, because grinding draws on a jar, not on one vintage inside it. Other jars' remainders are the previous cycles' business.
- `Cycle.FillRemaining()` / `FillRemainingPct()` — event-derived, for closed cycles (export).
- `State.FillOnShelf()` / `State.CarriedOnShelf()` — live from the balances, for the dashboard and status, so reconciliations are felt.
- `Held()`/`Remaining()` keep their shelf semantics where the shelf is the subject: the supply projection and `Leftover`.

The dashboard card, `wits status`, `witsnap json` (new `carried_grams`/`carried_jars` fields) and `wits export` all speak fill now, with the remainder on its own line.

## Against the imported workbook

```
51.22 g  of 63 g · cycle 29 (started: 2026-07-09), day 26
███████████████████████████████████▊────────
3 products on the shelf · lasts ~30 days at 1.73 g per active day
+ 15.82 g carried from earlier cycles in 7 older jars
```

**Why 63 and not 60:** MAC1+ was refilled into a jar still holding 2.95 g of its previous fill. Those grams sit in a jar the fill *did* dispense into, and the rows below count that jar whole — excluding them would put the bar over 100 % on fill day. The denominator is "what this cycle's jars started with": 60 dispensed + 2.95 already in one of them. When no fill product carries its own remainder — the common case — it reads exactly "of 60 g".

The arithmetic closes: 19 g ground this cycle = 8.78 from the fill's jars + 10.22 from older jars; 26.04 carried at fill − 10.22 ground = 15.82 still on the shelf. Nothing hidden, nothing double-billed, and the sum on top is the sum of the rows below it.

## Tests

`TheFillIsNotTheShelf` (ledger) builds a two-cycle history with an unrefilled older jar and a same-product refill, pinning `Fill`, `FillRemaining`, `FillOnShelf` and `CarriedOnShelf`. `TestDashboardBillsTheFillNotTheShelf` (tui) renders the card and asserts headline, denominator and the carried line. The README's `wits status` example is refreshed to the new output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)