### PR TITLE
feat(analysis): date the cycle scope, and say whose jars were ground

### DIFF
--- a/pkg/tui/analysis.go
+++ b/pkg/tui/analysis.go
@@ -336,7 +336,13 @@ func (v analysisView) summary(a *App, events []journal.Event, width int) string 
 	t := a.theme
 	stats := ledger.Summarise(events)
 
-	scope := t.Subtitle.Render("Showing ") + t.PanelTitle.Render(scopes[v.scope]) +
+	label := scopes[v.scope]
+	if v.scope == 0 {
+		if c := a.data.Cycle(); c != nil {
+			label = fmt.Sprintf("%s (started: %s)", label, c.Start.Format("2006-01-02"))
+		}
+	}
+	scope := t.Subtitle.Render("Showing ") + t.PanelTitle.Render(label) +
 		t.Dim.Render("  ·  press s to change")
 
 	cols := lipgloss.JoinHorizontal(lipgloss.Top,
@@ -442,18 +448,46 @@ func (v analysisView) byProduct(a *App, events []journal.Event, width int) strin
 	for s := range totals {
 		slugs = append(slugs, s)
 	}
-	sort.Slice(slugs, func(i, j int) bool { return totals[slugs[i]] > totals[slugs[j]] })
+
+	// In the cycle scope the ranking is the fill's: its own products first,
+	// and the older cycles' jars ground during the window beneath them,
+	// muted and saying whose they are — the window is honest about them,
+	// and so is the label.
+	older := map[string]bool{}
+	if v.scope == 0 {
+		if c := a.data.Cycle(); c != nil {
+			own := map[string]bool{}
+			for _, slug := range c.Products {
+				own[slug] = true
+			}
+			for _, s := range slugs {
+				older[s] = !own[s]
+			}
+		}
+	}
+	sort.Slice(slugs, func(i, j int) bool {
+		if older[slugs[i]] != older[slugs[j]] {
+			return !older[slugs[i]]
+		}
+		return totals[slugs[i]] > totals[slugs[j]]
+	})
 
 	bars := make([]Bar, 0, len(slugs))
 	for _, s := range slugs {
 		active := len(days[s])
+		note := fmt.Sprintf("%.1f g · %2.0f%% · %s · %.2f g/day",
+			totals[s], totals[s]/ground*100, plural(active, "day"),
+			totals[s]/float64(max(active, 1)))
+		color := t.StashC
+		if older[s] {
+			note += " · older cycle"
+			color = t.AVBC
+		}
 		bars = append(bars, Bar{
 			Label: data.ProductName(s),
 			Value: totals[s],
-			Note: fmt.Sprintf("%.1f g · %2.0f%% · %s · %.2f g/day",
-				totals[s], totals[s]/ground*100, plural(active, "day"),
-				totals[s]/float64(max(active, 1))),
-			Color: t.StashC,
+			Note:  note,
+			Color: color,
 		})
 	}
 	return BarChart(bars, width, t)

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -267,6 +267,49 @@ func TestDashboardWallClockAndCycleStart(t *testing.T) {
 		"The storage card should date the cycle it counts")
 }
 
+// TestAnalysisCycleScopeNamesItsWindow pins the cycle scope's heading to the
+// fill's start date, and the by-product panel to saying which grinds drew on
+// older cycles' jars during the window.
+func TestAnalysisCycleScopeNamesItsWindow(t *testing.T) {
+	at := time.Date(2026, time.July, 9, 10, 0, 0, 0, time.UTC)
+	mk := func(typ journal.Type, product string, grams float64, day int) journal.Event {
+		from, to, _ := journal.Flow(typ)
+		return journal.Event{
+			Type: typ, Product: product, Grams: grams, From: from, To: to,
+			OccurredAt: at.AddDate(0, 0, day),
+		}
+	}
+	events := []journal.Event{
+		mk(journal.Purchase, "old", 10, -40),
+		mk(journal.Purchase, "wcake", 20, 0),
+		mk(journal.Grind, "wcake", 1, 1),
+		// The older jar, ground inside the new cycle's window.
+		mk(journal.Grind, "old", 3, 2),
+	}
+	products := &catalog.Catalog{}
+	require.NoError(t, products.Add(product("Khiron 20/1 Old Strain", "old")))
+	require.NoError(t, products.Add(product("Enua 22/1 Wedding Cake", "wcake")))
+	data := Data{
+		Workspace: &workspace.Workspace{
+			Products: products,
+			Devices:  &catalog.Devices{},
+			State:    ledger.Fold(events),
+		},
+		Now: at.AddDate(0, 0, 3),
+	}
+
+	out := render(t, data, analysisScreen, 120, 44)
+
+	assert.Contains(t, out, "this cycle (started: 2026-07-09)",
+		"The scope heading should date the fill it frames")
+	assert.Contains(t, out, "older cycle",
+		"A grind drawing on an older cycle's jar should say so")
+	older := strings.Index(out, "Khiron 20/1 Old Strain")
+	own := strings.Index(out, "Enua 22/1 Wedding Cake")
+	require.True(t, older > 0 && own > 0, "both jars ground in the window are listed")
+	assert.Less(t, own, older, "The fill's own products rank first, older jars beneath")
+}
+
 func TestAnalysisScopes(t *testing.T) {
 	app := New(sample(t))
 	app.screen = analysisScreen


### PR DESCRIPTION
## What

Analysis-round remarks from the screen-by-screen review:

1. **The cycle scope names its window** — `Showing this cycle (started: 2026-07-09) · press s to change`, matching the dashboard card.
2. **The by-product panel says whose jars were ground.** The "this cycle" scope is a time window (`c.Events`), so older cycles' jars ground during it appeared indistinguishable from the fill's own — Lemon Cookie and Wedding Cake, both in cycle 29's `Opening`, ground after the fill arrived. The panel now ranks the fill's products first, then the older jars beneath, muted and marked `· older cycle`:

```
Cantourage 25/1 MAC1+             ████████████──   5.7 g · 30% · 6 days · 0.95 g/day
420 Evolution 27/1 Ice Cream Cake ███████▊──────   3.1 g · 16% · 3 days · 1.03 g/day
Enua 36/1 Citrus Slap             ███████▋──────   2.9 g · 15% · 2 days · 1.46 g/day
Cannamedical 28/1 Lemon Cookie    █████████▊──── 3.7 g · 20% · 3 days · … · older cycle
Enua 22/1 Wedding Cake            █████████▎──── 3.6 g · 19% · 3 days · … · older cycle
```

The headline totals and the chart stay whole-window — GROUND 19 g still matches what the panel sums — per the reviewer's call: split the ranking, keep the period's truth.

## Tests

`TestAnalysisCycleScopeNamesItsWindow` builds an older jar ground inside a new cycle's window and asserts the dated heading, the `older cycle` marker, and the fill-first ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)